### PR TITLE
[FEAT] question 조회 paging 처리

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/config/SwaggerConfig.java
+++ b/src/main/java/com/skhuedin/skhuedin/config/SwaggerConfig.java
@@ -1,21 +1,33 @@
 package com.skhuedin.skhuedin.config;
 
+import com.fasterxml.classmate.TypeResolver;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.AlternateTypeRules;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Configuration
 @EnableSwagger2
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+    private final TypeResolver typeResolver;
 
     private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
@@ -41,6 +53,9 @@ public class SwaggerConfig {
     @Bean
     public Docket commonApi() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .alternateTypeRules(
+                        AlternateTypeRules.newRule(typeResolver.resolve(Pageable.class), typeResolver.resolve(Page.class))
+                )
                 .consumes(getConsumeContentTypes())
                 .produces(getProductContentTypes())
                 .apiInfo(apiInfo())
@@ -48,5 +63,19 @@ public class SwaggerConfig {
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.ant("/api/**"))
                 .build();
+    }
+
+    @Getter @Setter
+    @ApiModel
+    static class Page {
+
+        @ApiModelProperty(value = "페이지 번호(0부터 시작)")
+        private Integer page;
+
+        @ApiModelProperty(value = "페이지 크기", allowableValues="range[0, 20]")
+        private Integer size;
+
+        @ApiModelProperty(value = "정렬(사용법: 컬럼명,ASC|DESC)")
+        private List<String> sort;
     }
 }

--- a/src/main/java/com/skhuedin/skhuedin/controller/QuestionApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/QuestionApiController.java
@@ -7,7 +7,10 @@ import com.skhuedin.skhuedin.dto.question.QuestionSaveRequestDto;
 import com.skhuedin.skhuedin.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -42,8 +45,10 @@ public class QuestionApiController {
     }
 
     @GetMapping("users/{targetUserId}/questions")
-    public ResponseEntity<? extends BasicResponse> findByTargetId(@PathVariable("targetUserId") Long id,
-                                                                  Pageable pageable) {
+    public ResponseEntity<? extends BasicResponse> findByTargetId(
+            @PathVariable("targetUserId") Long id,
+            @PageableDefault(sort="lastModifiedDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
         Page<QuestionMainResponseDto> questions = questionService.findByTargetUserId(id, pageable);
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(questions));

--- a/src/main/java/com/skhuedin/skhuedin/controller/QuestionApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/QuestionApiController.java
@@ -6,6 +6,8 @@ import com.skhuedin.skhuedin.dto.question.QuestionMainResponseDto;
 import com.skhuedin.skhuedin.dto.question.QuestionSaveRequestDto;
 import com.skhuedin.skhuedin.service.QuestionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,8 +18,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -42,8 +42,9 @@ public class QuestionApiController {
     }
 
     @GetMapping("users/{targetUserId}/questions")
-    public ResponseEntity<? extends BasicResponse> findByTargetId(@PathVariable("targetUserId") Long id) {
-        List<QuestionMainResponseDto> questions = questionService.findByTargetUserId(id);
+    public ResponseEntity<? extends BasicResponse> findByTargetId(@PathVariable("targetUserId") Long id,
+                                                                  Pageable pageable) {
+        Page<QuestionMainResponseDto> questions = questionService.findByTargetUserId(id, pageable);
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(questions));
     }
@@ -61,7 +62,7 @@ public class QuestionApiController {
     public ResponseEntity<? extends BasicResponse> delete(@PathVariable("questionId") Long id) {
         questionService.delete(id);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(new CommonResponse<>("삭제에 성공하였습니다."));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PostMapping("questions/{questionId}/views")

--- a/src/main/java/com/skhuedin/skhuedin/repository/QuestionRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/QuestionRepository.java
@@ -1,6 +1,9 @@
 package com.skhuedin.skhuedin.repository;
 
 import com.skhuedin.skhuedin.domain.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +11,7 @@ import java.util.List;
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     List<Question> findByTargetUserIdOrderByLastModifiedDateDesc(Long id);
+
+    @EntityGraph(attributePaths = {"targetUser", "writerUser"})
+    Page<Question> findByTargetUserId(Long id, Pageable pageable);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/QuestionService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/QuestionService.java
@@ -8,6 +8,8 @@ import com.skhuedin.skhuedin.dto.question.QuestionSaveRequestDto;
 import com.skhuedin.skhuedin.repository.QuestionRepository;
 import com.skhuedin.skhuedin.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +64,15 @@ public class QuestionService {
                     return new QuestionMainResponseDto(question, comments);
                 })
                 .collect(Collectors.toList());
+    }
+
+    public Page<QuestionMainResponseDto> findByTargetUserId(Long id, Pageable pageable) {
+        Page<Question> questions = questionRepository.findByTargetUserId(id, pageable);
+        return questions
+                .map(question -> {
+                    List<CommentMainResponseDto> comments = commentService.findByQuestionId(question.getId());
+                    return new QuestionMainResponseDto(question, comments);
+                });
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,9 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        show_sql: false
         format_sql: true
 
 logging.level:
   org.hibernate.SQL: debug
-  org.hibernate.type: trace
+#  org.hibernate.type: trace

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,7 +4,31 @@ values (now(), now(), 'admin@email.com', '1234', 'admin', 'KAKAO', '/img', now()
        (now(), now(), 'user2@email.com', '1234', '전우치', 'KAKAO', '/img', now(), now());
 
 insert into question (target_user_id, writer_user_id, title, content, status, fix, view, created_date, last_modified_date)
-values (1, 2, 'spring', 'spring 공부 루트', false, false, 0, now(), now());
+values (1, 2, 'spring 1', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 2', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 3', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 4', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 5', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 6', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 7', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 8', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 9', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 10', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 11', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 12', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 13', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 14', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 15', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 16', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 17', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 18', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 19', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 20', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 21', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 22', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 23', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 24', 'spring 공부 루트', false, false, 0, now(), now()),
+       (1, 2, 'spring 25', 'spring 공부 루트', false, false, 0, now(), now());
 
 insert into comment (question_id, writer_user_id, content, parent_comment_id, created_date, last_modified_date)
 values (1, 2, 'parent 댓글 1', null, now(), now()),

--- a/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +21,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Sql("/truncate.sql")
+@Transactional
 class QuestionRepositoryTest {
 
     @Autowired
@@ -87,6 +94,42 @@ class QuestionRepositoryTest {
                 () -> assertEquals(questions.get(0).getLastModifiedDate()
                         .compareTo(questions.get(1).getLastModifiedDate()), 1)
         );
+    }
+
+    @Test
+    @DisplayName("target user 의 id 별 question 목록을 paging 처리하여 조회하는 테스트")
+    void findByTargetUserId_paging() {
+
+        // given
+        for (int i = 0; i < 30; i++) {
+            Question question = generateQuestion(i);
+            questionRepository.save(question);
+        }
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0, 5,
+                Sort.by(Sort.Direction.DESC, "lastModifiedDate"));
+
+        Page<Question> page = questionRepository.findByTargetUserId(targetUser.getId(), pageRequest);
+
+        // then
+        assertEquals(page.getContent().size(), 5); // 조회된 데이터 수
+        assertEquals(page.getTotalElements(), 30); // 전체 데이터 수
+        assertEquals(page.getNumber(), 0); // 페이지 번호
+        assertEquals(page.getTotalPages(), 6); // 전체 페이지 번호
+        assertTrue(page.isFirst()); // 첫 번째 페이지 t/f
+        assertTrue(page.hasNext()); // 다음 페이지 t/f
+    }
+
+    private Question generateQuestion(int index) {
+        return Question.builder()
+                .targetUser(targetUser)
+                .writerUser(writerUser)
+                .title("질문 " + index)
+                .content("질문의 질문 내용")
+                .status(false)
+                .fix(false)
+                .build();
     }
 
     @AfterEach

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,8 +13,9 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        show_sql: false
         format_sql: true
 
 logging.level:
   org.hibernate.SQL: debug
-  org.hibernate.type: trace
+#  org.hibernate.type: trace


### PR DESCRIPTION
#72 

question을 조회할 때 모든 데이터를 조회하는 것이 아닌 프론트에서 특정한 페이지와 사이즈에 맞춰서 데이터를 전달할 수 있도록 조정하였습니다.

```
http://localhost:8080/api/users/1/questions?page=1&size=5&sort=lastModifiedDate,desc
```
위와 같이 query string을 활용하여 전달하면 DB에 조회할 때 값에 따른 쿼리를 날려 반환해 줍니다!