### PR TITLE
[FEAT] n + 1문제 확인 위한 테스트 추가 및 수정

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/repository/CommentRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.skhuedin.skhuedin.repository;
 
 import com.skhuedin.skhuedin.domain.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,7 +10,10 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @EntityGraph(attributePaths = {"question" , "writerUser", "parent"})
     @Query("select c from Comment c where c.question.id = :questionId and c.parent is null")
     List<Comment> findByQuestionId(@Param("questionId") Long questionId);
+
+    @EntityGraph(attributePaths = {"question" , "writerUser", "parent"})
     List<Comment> findByParentId(Long parentId);
 }

--- a/src/main/java/com/skhuedin/skhuedin/repository/CommentRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/CommentRepository.java
@@ -10,10 +10,11 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @EntityGraph(attributePaths = {"question" , "writerUser", "parent"})
+    @EntityGraph(
+            attributePaths = {"question", "question.targetUser", "question.writerUser", "writerUser"})
     @Query("select c from Comment c where c.question.id = :questionId and c.parent is null")
     List<Comment> findByQuestionId(@Param("questionId") Long questionId);
 
-    @EntityGraph(attributePaths = {"question" , "writerUser", "parent"})
+    @EntityGraph(attributePaths = {"question", "question.targetUser", "question.writerUser", "writerUser"})
     List<Comment> findByParentId(Long parentId);
 }

--- a/src/main/java/com/skhuedin/skhuedin/repository/QuestionRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/QuestionRepository.java
@@ -6,12 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    List<Question> findByTargetUserIdOrderByLastModifiedDateDesc(Long id);
-
-    @EntityGraph(attributePaths = {"targetUser", "writerUser"})
+    @EntityGraph(attributePaths = {"writerUser"})
     Page<Question> findByTargetUserId(Long id, Pageable pageable);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/QuestionService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/QuestionService.java
@@ -56,16 +56,6 @@ public class QuestionService {
         return new QuestionMainResponseDto(question, comments);
     }
 
-    public List<QuestionMainResponseDto> findByTargetUserId(Long id) {
-        List<Question> questions = questionRepository.findByTargetUserIdOrderByLastModifiedDateDesc(id);
-        return questions.stream()
-                .map(question -> {
-                    List<CommentMainResponseDto> comments = commentService.findByQuestionId(question.getId());
-                    return new QuestionMainResponseDto(question, comments);
-                })
-                .collect(Collectors.toList());
-    }
-
     public Page<QuestionMainResponseDto> findByTargetUserId(Long id, Pageable pageable) {
         Page<Question> questions = questionRepository.findByTargetUserId(id, pageable);
         return questions

--- a/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
@@ -13,8 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @Sql("/truncate.sql")
-@Transactional
 class QuestionRepositoryTest {
 
     @Autowired
@@ -30,6 +29,9 @@ class QuestionRepositoryTest {
 
     @Autowired
     QuestionRepository questionRepository;
+
+    @Autowired
+    EntityManager em;
 
     User targetUser;
     User writerUser;
@@ -121,6 +123,38 @@ class QuestionRepositoryTest {
         assertTrue(page.hasNext()); // 다음 페이지 t/f
     }
 
+    @Test
+    @DisplayName("findByTargetUserId의 N + 1 문제를 확인하는 테스트")
+    void findByTargetId_N1() {
+
+        // given
+        for (int i = 0; i < 10; i++) {
+            User writerUser = generateUser(i);
+            userRepository.save(writerUser);
+            Question question = generateQuestion(writerUser, i);
+            questionRepository.save(question);
+        }
+
+        // when
+        em.flush();
+        em.clear();
+        PageRequest pageRequest = PageRequest.of(0, 5,
+                Sort.by(Sort.Direction.DESC, "lastModifiedDate"));
+
+        Page<Question> page = questionRepository.findByTargetUserId(targetUser.getId(), pageRequest);
+        for (Question question : page) {
+            question.getWriterUser().getEmail(); // 의도적으로 사용
+        }
+
+        // then
+        assertEquals(page.getContent().size(), 5); // 조회된 데이터 수
+        assertEquals(page.getTotalElements(), 10); // 전체 데이터 수
+        assertEquals(page.getNumber(), 0); // 페이지 번호
+        assertEquals(page.getTotalPages(), 2); // 전체 페이지 번호
+        assertTrue(page.isFirst()); // 첫 번째 페이지 t/f
+        assertTrue(page.hasNext()); // 다음 페이지 t/f
+    }
+
     private Question generateQuestion(int index) {
         return Question.builder()
                 .targetUser(targetUser)
@@ -129,6 +163,29 @@ class QuestionRepositoryTest {
                 .content("질문의 질문 내용")
                 .status(false)
                 .fix(false)
+                .build();
+    }
+
+    private Question generateQuestion(User writerUser, int index) {
+        return Question.builder()
+                .targetUser(targetUser)
+                .writerUser(writerUser)
+                .title("질문 " + index)
+                .content("질문의 질문 내용")
+                .status(false)
+                .fix(false)
+                .build();
+    }
+
+    User generateUser(int index) {
+        return User.builder()
+                .email("user" + index + "@email.com")
+                .password("1234")
+                .name("user" + index)
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now())
+                .provider(Provider.SELF)
                 .build();
     }
 

--- a/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/QuestionRepositoryTest.java
@@ -63,42 +63,6 @@ class QuestionRepositoryTest {
     }
 
     @Test
-    @DisplayName("target user 의 id 별 question 목록을 수정날짜 내림차순으로 조회하는 테스트")
-    void findByTargetId() {
-
-        // given
-        Question question1 = Question.builder()
-                .targetUser(targetUser)
-                .writerUser(writerUser)
-                .title("질문 1")
-                .content("질문1의 질문 내용")
-                .status(false)
-                .fix(false)
-                .build();
-
-        Question question2 = Question.builder()
-                .targetUser(targetUser)
-                .writerUser(writerUser)
-                .title("질문 2")
-                .content("질문2의 질문 내용")
-                .status(false)
-                .fix(false)
-                .build();
-
-        questionRepository.save(question1);
-        questionRepository.save(question2);
-
-        // when
-        List<Question> questions = questionRepository.findByTargetUserIdOrderByLastModifiedDateDesc(targetUser.getId());
-
-        // then
-        assertAll(
-                () -> assertEquals(questions.get(0).getLastModifiedDate()
-                        .compareTo(questions.get(1).getLastModifiedDate()), 1)
-        );
-    }
-
-    @Test
     @DisplayName("target user 의 id 별 question 목록을 paging 처리하여 조회하는 테스트")
     void findByTargetUserId_paging() {
 

--- a/src/test/java/com/skhuedin/skhuedin/service/QuestionServiceTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/service/QuestionServiceTest.java
@@ -192,26 +192,6 @@ class QuestionServiceTest {
     }
 
     @Test
-    @DisplayName("target user id 로 question 을 조회하는 테스트")
-    void findByTargetUserId() {
-
-        // given
-        QuestionSaveRequestDto requestDto1 = generateRequestDto();
-        QuestionSaveRequestDto requestDto2 = generateRequestDto();
-        QuestionSaveRequestDto requestDto3 = generateRequestDto();
-
-        questionService.save(requestDto1);
-        questionService.save(requestDto2);
-        questionService.save(requestDto3);
-
-        // when
-        List<QuestionMainResponseDto> questions = questionService.findByTargetUserId(targetUser.getId());
-
-        // then
-        assertEquals(questions.size(), 3);
-    }
-
-    @Test
     @DisplayName("target user id 로 question 목록을 paging 하여 조회하는 테스트")
     void findByTargetId_paging() {
 


### PR DESCRIPTION
#79 
question 및 comment의 n + 1문제를 확인하였고, 적절히 수정하였습니다.

수정 전 한 번 쿼리를 조회하여 for 문으로 n 번 접근할 때 마다 매번 조회를 진행합니다.
![n + 1](https://user-images.githubusercontent.com/59357153/117626610-3ff13700-b1b2-11eb-8704-481ab086c652.PNG)

수정 후 즉시 조회하여 한 번의 쿼리로 모든 데이터를 받아옵니다.
![n + 1 해결](https://user-images.githubusercontent.com/59357153/117626733-61522300-b1b2-11eb-93a7-1e3dbdec6fbf.PNG)

어려운 부분이 많아요.. 적절히 잘 적용되었는지 확인 한 번 부탁드립니다!

## 참고사항
[JPA N+1 문제 및 해결방안](https://jojoldu.tistory.com/165)
