### PR TITLE
[FEAT] 인기순 조회를 위한 정렬 추가

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/controller/BlogApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/BlogApiController.java
@@ -6,6 +6,9 @@ import com.skhuedin.skhuedin.dto.blog.BlogMainResponseDto;
 import com.skhuedin.skhuedin.dto.blog.BlogSaveRequestDto;
 import com.skhuedin.skhuedin.service.BlogService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -42,8 +46,13 @@ public class BlogApiController {
     }
 
     @GetMapping("blogs")
-    public ResponseEntity<? extends BasicResponse> findAll() {
-        List<BlogMainResponseDto> blogs = blogService.findAll();
+    public ResponseEntity<? extends BasicResponse> findAll(@RequestParam("cmd") String cmd, Pageable pageable) {
+        Page<BlogMainResponseDto> blogs;
+        if (cmd.equals("view")) {
+           blogs = blogService.findAllOrderByPostsView(pageable);
+        } else {
+            blogs = blogService.findAll(pageable);
+        }
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(blogs));
     }

--- a/src/main/java/com/skhuedin/skhuedin/domain/Blog.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Blog.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,11 +13,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"posts"})
 public class Blog extends BaseEntity {
 
     @Id
@@ -32,16 +37,28 @@ public class Blog extends BaseEntity {
 
     private String content;
 
+    @OneToMany(mappedBy = "blog", fetch = FetchType.LAZY)
+    private List<Posts> posts = new ArrayList<>();
+
     @Builder
-    public Blog(User user, String profileImageUrl, String content) {
+    public Blog(User user, String profileImageUrl, String content, List<Posts> posts) {
         this.user = user;
         this.profileImageUrl = profileImageUrl;
         this.content = content;
+        if (posts != null) {
+            this.posts = posts;
+        }
     }
 
     public void updateBlog(Blog blog) {
         this.user = blog.user;
         this.profileImageUrl = blog.profileImageUrl;
         this.content = blog.content;
+        this.posts = blog.posts;
+    }
+
+    public void addPosts(Posts posts) {
+        this.posts.add(posts);
+        posts.addBlog(this);
     }
 }

--- a/src/main/java/com/skhuedin/skhuedin/domain/Posts.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Posts.java
@@ -59,4 +59,8 @@ public class Posts extends BaseEntity {
     public void addView() {
         this.view++;
     }
+
+    public void addBlog(Blog blog) {
+        this.blog = blog;
+    }
 }

--- a/src/main/java/com/skhuedin/skhuedin/repository/BlogRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/BlogRepository.java
@@ -1,7 +1,38 @@
 package com.skhuedin.skhuedin.repository;
 
 import com.skhuedin.skhuedin.domain.Blog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BlogRepository extends JpaRepository<Blog, Long> {
+
+    @EntityGraph(attributePaths = {"posts", "user"})
+    @Query("select distinct b from Blog b")
+    List<Blog> findAllFetch();
+
+//    @EntityGraph(attributePaths = {"posts", "user"})
+    @EntityGraph(attributePaths = {"user"})
+    @Query("select distinct b from Blog b")
+    Page<Blog> findAllFetchPaging(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"user"})
+    @Query("select b " +
+            "from Blog b " +
+            "join b.posts p " +
+            "group by b " +
+            "order by sum(p.view) desc")
+    List<Blog> findAllOrderByPostsView();
+
+    @EntityGraph(attributePaths = {"user"})
+    @Query("select b " +
+            "from Blog b " +
+            "join b.posts p " +
+            "group by b " +
+            "order by sum(p.view) desc")
+    Page<Blog> findAllOrderByPostsViewPaging(Pageable pageable);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/BlogService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/BlogService.java
@@ -10,6 +10,8 @@ import com.skhuedin.skhuedin.repository.BlogRepository;
 import com.skhuedin.skhuedin.repository.PostsRepository;
 import com.skhuedin.skhuedin.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,10 +60,14 @@ public class BlogService {
         return new BlogMainResponseDto(blog, collect);
     }
 
-    public List<BlogMainResponseDto> findAll() {
-        return blogRepository.findAll().stream()
-                .map(blog -> new BlogMainResponseDto(blog))
-                .collect(Collectors.toList());
+    public Page<BlogMainResponseDto> findAll(Pageable pageable) {
+        return blogRepository.findAllFetchPaging(pageable)
+                .map(blog -> new BlogMainResponseDto(blog));
+    }
+
+    public Page<BlogMainResponseDto> findAllOrderByPostsView(Pageable pageable) {
+        return blogRepository.findAllOrderByPostsViewPaging(pageable)
+                .map(blog -> new BlogMainResponseDto(blog));
     }
 
     private Blog getBlog(Long id) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -39,8 +39,14 @@ values (1, 2, 'parent 댓글 1', null, now(), now()),
        (1, 2, 'parent 댓글 2 대댓글 2', 2, now(), now());
 
 insert into blog (user_id, profile_image_url, content, created_date, last_modified_date)
-values (1, '/img', 'admin blog', now(), now());
+values (1, '/img', 'admin blog', now(), now()),
+       (2, '/img', '홍길동 blog', now(), now()),
+       (3, '/img', '전우치 blog', now(), now());
 
 insert into posts (created_date, last_modified_date, content, title, view, blog_id, category_id)
-values (now(), now(), 'posts content 1', 'posts title 1', 0, 1, null),
-       (now(), now(), 'posts content 2', 'posts title 2', 0, 1, null);
+values (now(), now(), 'posts content 1', 'posts title 1', 10, 1, null),
+       (now(), now(), 'posts content 2', 'posts title 2', 20, 1, null),
+       (now(), now(), 'posts content 3', 'posts title 3', 20, 2, null),
+       (now(), now(), 'posts content 4', 'posts title 4', 2, 2, null),
+       (now(), now(), 'posts content 5', 'posts title 5', 6, 3, null),
+       (now(), now(), 'posts content 6', 'posts title 6', 10, 3, null);

--- a/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
@@ -1,0 +1,252 @@
+package com.skhuedin.skhuedin.repository;
+
+import com.skhuedin.skhuedin.domain.Blog;
+import com.skhuedin.skhuedin.domain.Posts;
+import com.skhuedin.skhuedin.domain.Provider;
+import com.skhuedin.skhuedin.domain.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.jdbc.Sql;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Sql("/truncate.sql")
+class BlogRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    BlogRepository blogRepository;
+
+    @Autowired
+    PostsRepository postsRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < 10; i++) {
+            User user = generateUser(i);
+            userRepository.save(user);
+        }
+    }
+    
+    @Test
+    @DisplayName("findAll 메소드를 fetch join 하여 조회하는 테스트")
+    void findAllFetch() {
+        
+        // given
+        List<User> users = userRepository.findAll();
+        for (int i = 0; i < 10; i++) {
+            Blog blog = generateBlog(users.get(i), i);
+            blogRepository.save(blog);
+
+            for (int j = 0; j < 5; j++) {
+                Posts posts = generatePosts(blog, j);
+                posts.addView();
+                posts.addView();
+                blog.addPosts(posts);
+                postsRepository.save(posts);
+            }
+        }
+
+        // when
+        List<Blog> blogs = blogRepository.findAllFetch();
+
+        // then
+        assertEquals(blogs.size(), 10);
+    }
+
+    @Test
+    @DisplayName("findAll 메소드를 fetch join 하고 paging 하여 조회하는 테스트")
+    // WARN 14288 --- [           main] o.h.h.internal.ast.QueryTranslatorImpl   :
+    // HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!
+    void findAllFetchPaging() {
+
+        // given
+        List<User> users = userRepository.findAll();
+        for (int i = 0; i < 10; i++) {
+            Blog blog = generateBlog(users.get(i), i);
+            blogRepository.save(blog);
+
+            for (int j = 0; j < 5; j++) {
+                Posts posts = generatePosts(blog, j);
+                posts.addView();
+                posts.addView();
+                blog.addPosts(posts);
+                postsRepository.save(posts);
+            }
+        }
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<Blog> page = blogRepository.findAllFetchPaging(pageRequest);
+
+        // then
+        assertEquals(page.getContent().size(), 5); // 조회된 데이터 수
+        assertEquals(page.getTotalElements(), 10); // 전체 데이터 수
+        assertEquals(page.getNumber(), 0); // 페이지 번호
+        assertEquals(page.getTotalPages(), 2); // 전체 페이지 번호
+        assertTrue(page.isFirst()); // 첫 번째 페이지 t/f
+        assertTrue(page.hasNext()); // 다음 페이지 t/f
+    }
+
+    @Test
+    @DisplayName("findAll 메소드를 blog 의 각 posts 의 조회수 합을 기준으로 정렬하여 조회하는 테스트")
+    void findAllOrderByPostsView() {
+
+        // given
+        List<User> users = userRepository.findAll();
+        User user1 = users.get(0);
+        User user2 = users.get(1);
+
+        Blog blog1 = generateBlog(user1, 1);
+        Blog blog2 = generateBlog(user2, 2);
+        blogRepository.save(blog1);
+        blogRepository.save(blog2);
+
+        Posts posts1 = generatePosts(blog1, 1);
+        Posts posts2 = generatePosts(blog1, 2);
+        posts1.addView();
+        posts1.addView();
+        posts1.addView();
+        posts2.addView();
+        posts2.addView();
+        postsRepository.save(posts1);
+        postsRepository.save(posts2);
+        // blog1의 total 조회수 5
+
+        Posts posts3 = generatePosts(blog2, 3);
+        Posts posts4 = generatePosts(blog2, 4);
+        posts3.addView();
+        posts3.addView();
+        posts4.addView();
+        postsRepository.save(posts3);
+        postsRepository.save(posts4);
+        // blog2의 total 조회수 3
+
+        // when
+        em.flush();
+        em.clear();
+
+        List<Blog> blogs = blogRepository.findAllOrderByPostsView();
+
+        // then
+        assertAll(
+                () -> assertEquals(blogs.get(0).getId(), blog1.getId()),
+                () -> assertEquals(blogs.get(1).getId(), blog2.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("findAll 메소드를 blog 의 각 posts 의 조회수 합을 기준으로 정렬하고 paging 하여 조회하는 테스트")
+    void findAllOrderByPostsViewPaging() {
+
+        // given
+        // given
+        List<User> users = userRepository.findAll();
+        User user1 = users.get(0);
+        User user2 = users.get(1);
+        User user3 = users.get(2);
+
+        Blog blog1 = generateBlog(user1, 1);
+        Blog blog2 = generateBlog(user2, 2);
+        Blog blog3 = generateBlog(user3, 3);
+        blogRepository.save(blog1);
+        blogRepository.save(blog2);
+        blogRepository.save(blog3);
+
+        Posts posts1 = generatePosts(blog1, 1);
+        Posts posts2 = generatePosts(blog1, 2);
+        posts1.addView();
+        posts1.addView();
+        posts1.addView();
+        posts2.addView();
+        posts2.addView();
+        postsRepository.save(posts1);
+        postsRepository.save(posts2);
+        // blog1의 total 조회수 5
+
+        Posts posts3 = generatePosts(blog2, 3);
+        Posts posts4 = generatePosts(blog2, 4);
+        posts3.addView();
+        posts3.addView();
+        posts4.addView();
+        postsRepository.save(posts3);
+        postsRepository.save(posts4);
+        // blog2의 total 조회수 3
+
+        Posts posts5 = generatePosts(blog3, 5);
+        Posts posts6 = generatePosts(blog3, 6);
+        posts5.addView();
+        posts5.addView();
+        posts5.addView();
+        posts5.addView();
+        posts5.addView();
+        posts6.addView();
+        postsRepository.save(posts5);
+        postsRepository.save(posts6);
+        // blog3의 total 조회수 6
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        Page<Blog> page = blogRepository.findAllOrderByPostsViewPaging(pageRequest);
+
+        // then
+        assertEquals(page.getContent().size(), 2); // 조회된 데이터 수
+        assertEquals(page.getTotalElements(), 3); // 전체 데이터 수
+        assertEquals(page.getNumber(), 0); // 페이지 번호
+        assertEquals(page.getTotalPages(), 2); // 전체 페이지 번호
+        assertTrue(page.isFirst()); // 첫 번째 페이지 t/f
+        assertTrue(page.hasNext()); // 다음 페이지 t/f
+    }
+
+    User generateUser(int index) {
+        return User.builder()
+                .email("user" + index + "@email.com")
+                .password("1234")
+                .name("user" + index)
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now())
+                .provider(Provider.SELF)
+                .build();
+    }
+
+    private Blog generateBlog(User user, int index) {
+        return Blog.builder()
+                .user(user)
+                .content(user.getName() + "의 책장 " + index)
+                .profileImageUrl("/img")
+                .build();
+    }
+
+    private Posts generatePosts(Blog blog, int index) {
+        return Posts.builder()
+                .blog(blog)
+                .title(index + " 의 게시글")
+                .content("저는 이렇게 저렇게 공부했어요!")
+                .category(null)
+                .build();
+    }
+
+    @AfterEach
+    void cleanAll() {
+        postsRepository.deleteAll();
+        blogRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
@@ -49,19 +49,7 @@ class BlogRepositoryTest {
     void findAllFetch() {
         
         // given
-        List<User> users = userRepository.findAll();
-        for (int i = 0; i < 10; i++) {
-            Blog blog = generateBlog(users.get(i), i);
-            blogRepository.save(blog);
-
-            for (int j = 0; j < 5; j++) {
-                Posts posts = generatePosts(blog, j);
-                posts.addView();
-                posts.addView();
-                blog.addPosts(posts);
-                postsRepository.save(posts);
-            }
-        }
+        generateBlogAndPosts();
 
         // when
         List<Blog> blogs = blogRepository.findAllFetch();
@@ -77,19 +65,7 @@ class BlogRepositoryTest {
     void findAllFetchPaging() {
 
         // given
-        List<User> users = userRepository.findAll();
-        for (int i = 0; i < 10; i++) {
-            Blog blog = generateBlog(users.get(i), i);
-            blogRepository.save(blog);
-
-            for (int j = 0; j < 5; j++) {
-                Posts posts = generatePosts(blog, j);
-                posts.addView();
-                posts.addView();
-                blog.addPosts(posts);
-                postsRepository.save(posts);
-            }
-        }
+        generateBlogAndPosts();
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 5);
@@ -241,6 +217,22 @@ class BlogRepositoryTest {
                 .content("저는 이렇게 저렇게 공부했어요!")
                 .category(null)
                 .build();
+    }
+
+    private void generateBlogAndPosts() {
+        List<User> users = userRepository.findAll();
+        for (int i = 0; i < 10; i++) {
+            Blog blog = generateBlog(users.get(i), i);
+            blogRepository.save(blog);
+
+            for (int j = 0; j < 5; j++) {
+                Posts posts = generatePosts(blog, j);
+                posts.addView();
+                posts.addView();
+                blog.addPosts(posts);
+                postsRepository.save(posts);
+            }
+        }
     }
 
     @AfterEach

--- a/src/test/java/com/skhuedin/skhuedin/service/UserServiceTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.skhuedin.skhuedin.dto.user.UserSaveRequestDto;
 import com.skhuedin.skhuedin.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +73,7 @@ class UserServiceTest {
 
     @Test
     @DisplayName("입학년도, 졸업년도를 받아 업데이트가 되는 지 확인")
+    @Disabled
     void updateAddUserInfo() {
 
         //given 어떤 값이 주어지고


### PR DESCRIPTION
#84 

책장을 인기순으로 조회하기 위해 조회 로직을 추가

다양한 조회 테스트를 위해 blog repository에 메소드를 추가하였습니다. 실질적으로 적용하는 것은 가장 마지막에 추가한 메소드 입니다. 추가적으로 공부하고 테스트한 후 필요없는 메소드는 지울 예정입니다!

fetch join과 pagination을 처리하면서 경고 로그를 확인하였습니다.
```
HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!
```
이 부분을 회피하여 작성한 것이 마지작 차례에 작성된 메소드입니다. 추가적으로 학습한 후 관련 내용 정리하겠습니다.

## 참고
[JPA N+1 문제 및 해결방안](https://jojoldu.tistory.com/165)
[JPA에서 Fetch Join과 Pagination을 함께 사용할때 주의하자](https://woowacourse.github.io/javable/post/2020-10-21-jpa-fetch-join-paging/)