### PR TITLE
[FEAT] blog 정렬 조건 추가

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/common/exception/ExceptionController.java
+++ b/src/main/java/com/skhuedin/skhuedin/common/exception/ExceptionController.java
@@ -2,6 +2,7 @@ package com.skhuedin.skhuedin.common.exception;
 
 import com.skhuedin.skhuedin.controller.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,6 +11,16 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 @Slf4j
 public class ExceptionController {
+
+    // 400
+    @ExceptionHandler({InvalidDataAccessApiUsageException.class})
+    public ResponseEntity<ErrorResponse> BadRequestException(RuntimeException e) {
+        log.warn("error", e);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("잘못된 정렬 조건입니다.", "400"));
+    }
 
     // 401
     @ExceptionHandler({EmptyTokenException.class})

--- a/src/main/java/com/skhuedin/skhuedin/controller/BlogApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/BlogApiController.java
@@ -8,7 +8,6 @@ import com.skhuedin.skhuedin.service.BlogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,8 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -46,10 +43,11 @@ public class BlogApiController {
     }
 
     @GetMapping("blogs")
-    public ResponseEntity<? extends BasicResponse> findAll(@RequestParam("cmd") String cmd, Pageable pageable) {
+    public ResponseEntity<? extends BasicResponse> findAll(@RequestParam(value = "cmd", defaultValue = "") String cmd,
+                                                           Pageable pageable) {
         Page<BlogMainResponseDto> blogs;
         if (cmd.equals("view")) {
-           blogs = blogService.findAllOrderByPostsView(pageable);
+            blogs = blogService.findAllOrderByPostsView(pageable);
         } else {
             blogs = blogService.findAll(pageable);
         }

--- a/src/main/java/com/skhuedin/skhuedin/repository/BlogRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/BlogRepository.java
@@ -7,18 +7,11 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
-
 public interface BlogRepository extends JpaRepository<Blog, Long> {
 
-    @EntityGraph(attributePaths = {"posts", "user"})
-    @Query("select distinct b from Blog b")
-    List<Blog> findAllFetch();
-
-//    @EntityGraph(attributePaths = {"posts", "user"})
     @EntityGraph(attributePaths = {"user"})
-    @Query("select distinct b from Blog b")
-    Page<Blog> findAllFetchPaging(Pageable pageable);
+    @Query("select distinct b from Blog b join b.user u")
+    Page<Blog> findAll(Pageable pageable);
 
     @EntityGraph(attributePaths = {"user"})
     @Query("select b " +
@@ -26,13 +19,5 @@ public interface BlogRepository extends JpaRepository<Blog, Long> {
             "join b.posts p " +
             "group by b " +
             "order by sum(p.view) desc")
-    List<Blog> findAllOrderByPostsView();
-
-    @EntityGraph(attributePaths = {"user"})
-    @Query("select b " +
-            "from Blog b " +
-            "join b.posts p " +
-            "group by b " +
-            "order by sum(p.view) desc")
-    Page<Blog> findAllOrderByPostsViewPaging(Pageable pageable);
+    Page<Blog> findAllOrderByPostsView(Pageable pageable);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/BlogService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/BlogService.java
@@ -61,12 +61,12 @@ public class BlogService {
     }
 
     public Page<BlogMainResponseDto> findAll(Pageable pageable) {
-        return blogRepository.findAllFetchPaging(pageable)
+        return blogRepository.findAll(pageable)
                 .map(blog -> new BlogMainResponseDto(blog));
     }
 
     public Page<BlogMainResponseDto> findAllOrderByPostsView(Pageable pageable) {
-        return blogRepository.findAllOrderByPostsViewPaging(pageable)
+        return blogRepository.findAllOrderByPostsView(pageable)
                 .map(blog -> new BlogMainResponseDto(blog));
     }
 

--- a/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/BlogRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.jdbc.Sql;
 
 import javax.persistence.EntityManager;
@@ -43,95 +44,137 @@ class BlogRepositoryTest {
             userRepository.save(user);
         }
     }
-    
-    @Test
-    @DisplayName("findAll 메소드를 fetch join 하여 조회하는 테스트")
-    void findAllFetch() {
-        
-        // given
-        generateBlogAndPosts();
-
-        // when
-        List<Blog> blogs = blogRepository.findAllFetch();
-
-        // then
-        assertEquals(blogs.size(), 10);
-    }
 
     @Test
     @DisplayName("findAll 메소드를 fetch join 하고 paging 하여 조회하는 테스트")
     // WARN 14288 --- [           main] o.h.h.internal.ast.QueryTranslatorImpl   :
     // HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!
-    void findAllFetchPaging() {
+    void findAll() {
 
         // given
         generateBlogAndPosts();
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 5);
-        Page<Blog> page = blogRepository.findAllFetchPaging(pageRequest);
-
-        // then
-        assertEquals(page.getContent().size(), 5); // 조회된 데이터 수
-        assertEquals(page.getTotalElements(), 10); // 전체 데이터 수
-        assertEquals(page.getNumber(), 0); // 페이지 번호
-        assertEquals(page.getTotalPages(), 2); // 전체 페이지 번호
-        assertTrue(page.isFirst()); // 첫 번째 페이지 t/f
-        assertTrue(page.hasNext()); // 다음 페이지 t/f
-    }
-
-    @Test
-    @DisplayName("findAll 메소드를 blog 의 각 posts 의 조회수 합을 기준으로 정렬하여 조회하는 테스트")
-    void findAllOrderByPostsView() {
-
-        // given
-        List<User> users = userRepository.findAll();
-        User user1 = users.get(0);
-        User user2 = users.get(1);
-
-        Blog blog1 = generateBlog(user1, 1);
-        Blog blog2 = generateBlog(user2, 2);
-        blogRepository.save(blog1);
-        blogRepository.save(blog2);
-
-        Posts posts1 = generatePosts(blog1, 1);
-        Posts posts2 = generatePosts(blog1, 2);
-        posts1.addView();
-        posts1.addView();
-        posts1.addView();
-        posts2.addView();
-        posts2.addView();
-        postsRepository.save(posts1);
-        postsRepository.save(posts2);
-        // blog1의 total 조회수 5
-
-        Posts posts3 = generatePosts(blog2, 3);
-        Posts posts4 = generatePosts(blog2, 4);
-        posts3.addView();
-        posts3.addView();
-        posts4.addView();
-        postsRepository.save(posts3);
-        postsRepository.save(posts4);
-        // blog2의 total 조회수 3
-
-        // when
-        em.flush();
-        em.clear();
-
-        List<Blog> blogs = blogRepository.findAllOrderByPostsView();
+        Page<Blog> page = blogRepository.findAll(pageRequest);
 
         // then
         assertAll(
-                () -> assertEquals(blogs.get(0).getId(), blog1.getId()),
-                () -> assertEquals(blogs.get(1).getId(), blog2.getId())
+                () -> assertEquals(page.getContent().size(), 5), // 조회된 데이터 수
+                () -> assertEquals(page.getTotalElements(), 10), // 전체 데이터 수
+                () -> assertEquals(page.getNumber(), 0), // 페이지 번호
+                () -> assertEquals(page.getTotalPages(), 2), // 전체 페이지 번호
+                () -> assertTrue(page.isFirst()), // 첫 번째 페이지 t/f
+                () -> assertTrue(page.hasNext()) // 다음 페이지 t/f
+        );
+    }
+
+    @Test
+    @DisplayName("findAll 메소드를 user 의 졸업순으로 정렬하여 paging 조회하는 테스트")
+    void findAllOrderByUserEntranceYear() {
+
+        // given
+        userRepository.deleteAll();
+
+        User user1 = User.builder()
+                .email("user1@email.com")
+                .password("1234")
+                .name("user1")
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now().minusYears(2))
+                .provider(Provider.SELF)
+                .build();
+
+        User user2 = User.builder()
+                .email("user2@email.com")
+                .password("1234")
+                .name("user2")
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now().minusYears(1))
+                .provider(Provider.SELF)
+                .build();
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Blog blog1 = generateBlog(user1, 1);
+        Blog blog2 = generateBlog(user1, 2);
+
+        blogRepository.save(blog1);
+        blogRepository.save(blog2);
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("user.entranceYear"));
+        Page<Blog> page = blogRepository.findAll(pageRequest);
+
+        // then
+        assertAll(
+                () -> assertEquals(page.getContent().size(), 2), // 조회된 데이터 수
+                () -> assertEquals(page.getTotalElements(), 2), // 전체 데이터 수
+                () -> assertEquals(page.getNumber(), 0), // 페이지 번호
+                () -> assertEquals(page.getTotalPages(), 1), // 전체 페이지 번호
+                () -> assertTrue(page.isFirst()), // 첫 번째 페이지 t/f
+                () -> assertFalse(page.hasNext()) // 다음 페이지 t/f
+        );
+    }
+
+    @Test
+    @DisplayName("findAll 메소드를 user 의 최신 업데이트 순으로 정렬하여 paging 조회하는 테스트")
+    void findAllOrderByUserLastModifiedDate() {
+
+        // given
+        userRepository.deleteAll();
+
+        User user1 = User.builder()
+                .email("user1@email.com")
+                .password("1234")
+                .name("user1")
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now().minusYears(2))
+                .provider(Provider.SELF)
+                .build();
+
+        User user2 = User.builder()
+                .email("user2@email.com")
+                .password("1234")
+                .name("user2")
+                .userImageUrl("/img")
+                .graduationYear(LocalDateTime.now())
+                .entranceYear(LocalDateTime.now().minusYears(1))
+                .provider(Provider.SELF)
+                .build();
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Blog blog1 = generateBlog(user1, 1);
+        Blog blog2 = generateBlog(user1, 2);
+
+        blogRepository.save(blog1);
+        blogRepository.save(blog2);
+
+        // when
+        PageRequest pageRequest = PageRequest.of(0, 2, Sort.by("user.lastModifiedDate"));
+        Page<Blog> page = blogRepository.findAll(pageRequest);
+
+        // then
+        assertAll(
+                () -> assertEquals(page.getContent().size(), 2), // 조회된 데이터 수
+                () -> assertEquals(page.getTotalElements(), 2), // 전체 데이터 수
+                () -> assertEquals(page.getNumber(), 0), // 페이지 번호
+                () -> assertEquals(page.getTotalPages(), 1), // 전체 페이지 번호
+                () -> assertTrue(page.isFirst()), // 첫 번째 페이지 t/f
+                () -> assertFalse(page.hasNext()) // 다음 페이지 t/f
         );
     }
 
     @Test
     @DisplayName("findAll 메소드를 blog 의 각 posts 의 조회수 합을 기준으로 정렬하고 paging 하여 조회하는 테스트")
-    void findAllOrderByPostsViewPaging() {
-
-        // given
+    void findAllOrderByPostsView() {
+        
         // given
         List<User> users = userRepository.findAll();
         User user1 = users.get(0);
@@ -179,7 +222,7 @@ class BlogRepositoryTest {
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 2);
-        Page<Blog> page = blogRepository.findAllOrderByPostsViewPaging(pageRequest);
+        Page<Blog> page = blogRepository.findAllOrderByPostsView(pageRequest);
 
         // then
         assertEquals(page.getContent().size(), 2); // 조회된 데이터 수

--- a/src/test/java/com/skhuedin/skhuedin/repository/PostsRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/PostsRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Sql("/truncate.sql")
 class PostsRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
#93 

blog 정렬 조건을 테스트하고 적절하지 않은 request가 던지는 예외를
catch하여 가공하여 error message를 response로 전달하게 설정

인기순
![image](https://user-images.githubusercontent.com/59357153/118350011-64bd2400-b58f-11eb-9072-9823622d4bca.png)

업데이트순
![image](https://user-images.githubusercontent.com/59357153/118350035-7ef70200-b58f-11eb-8798-2b851814fc3c.png)

졸업순
![image](https://user-images.githubusercontent.com/59357153/118350046-933aff00-b58f-11eb-8f09-9e447369fa05.png)

그 밖에 다양한 정렬조건들이 활용가능합니다.

만약 존재하지 않는 필드로 정렬을 시도한다면, 
![image](https://user-images.githubusercontent.com/59357153/118350063-ac43b000-b58f-11eb-90ea-cf8d23becd9e.png)

400 error를 던질 수 있도록 ExceptionController에 추가하였습니다.
