### PR TITLE
[FEAT] yml 파일 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+src/main/resources/data.yml
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/src/main/java/com/skhuedin/skhuedin/controller/AdminController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.skhuedin.skhuedin.controller;
 
+import com.skhuedin.skhuedin.controller.response.KakaoResponse;
 import com.skhuedin.skhuedin.domain.User;
 import com.skhuedin.skhuedin.dto.category.CategoryMainResponseDto;
 import com.skhuedin.skhuedin.dto.category.CategoryRequestDto;
@@ -10,6 +11,7 @@ import com.skhuedin.skhuedin.dto.user.UserMainResponseDto;
 import com.skhuedin.skhuedin.infra.MyRole;
 import com.skhuedin.skhuedin.infra.Role;
 import com.skhuedin.skhuedin.service.*;
+import com.skhuedin.skhuedin.yml.DataYamlRead;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -28,6 +30,7 @@ AdminController {
     private final QuestionService questionService;
     private final CategoryService categoryService;
     private final CommentService commentService;
+    private final DataYamlRead dataYamlRead;
 
     @MyRole(role = Role.ADMIN)
     @ResponseBody
@@ -137,6 +140,14 @@ AdminController {
     public List<QuestionMainResponseDto> questionList() {
         List<QuestionMainResponseDto> list = questionService.findAll();
         return list;
+    }
+
+
+    @ResponseBody
+    @GetMapping("/kakao")
+    public KakaoResponse kakao() {
+        KakaoResponse kakaoResponse = new KakaoResponse(dataYamlRead.getKakao());
+        return kakaoResponse;
     }
 
     @MyRole(role = Role.ADMIN)

--- a/src/main/java/com/skhuedin/skhuedin/controller/response/KakaoResponse.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/response/KakaoResponse.java
@@ -1,0 +1,16 @@
+package com.skhuedin.skhuedin.controller.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoResponse {
+    private String kakaoId;
+
+    public KakaoResponse(String kakaoId) {
+        this.kakaoId = kakaoId;
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/social/google/GoogleOauth.java
+++ b/src/main/java/com/skhuedin/skhuedin/social/google/GoogleOauth.java
@@ -9,6 +9,7 @@ import com.skhuedin.skhuedin.domain.Provider;
 import com.skhuedin.skhuedin.dto.user.UserSaveRequestDto;
 import com.skhuedin.skhuedin.social.SocialOauth;
 import com.skhuedin.skhuedin.social.kakao.OAuthToken;
+import com.skhuedin.skhuedin.yml.DataYamlRead;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +22,7 @@ import java.util.UUID;
 public class GoogleOauth implements SocialOauth {
 
     private final RestTemplate restTemplate;
+    private final DataYamlRead dataYamlRead;
 
     @Override
     public UserSaveRequestDto requestAccessToken(OAuthToken oAuthToken) {
@@ -33,7 +35,7 @@ public class GoogleOauth implements SocialOauth {
         mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        String reqURL = "https://www.googleapis.com/userinfo/v2/me?access_token=" + oAuthToken.getAccessToken();
+        String reqURL =  dataYamlRead.getGoogleReqURL()+ oAuthToken.getAccessToken();
         String resultJson = restTemplate.getForObject(reqURL, String.class);
         GoogleProfile profile = null;
 

--- a/src/main/java/com/skhuedin/skhuedin/social/kakao/KakaoOauth.java
+++ b/src/main/java/com/skhuedin/skhuedin/social/kakao/KakaoOauth.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skhuedin.skhuedin.domain.Provider;
 import com.skhuedin.skhuedin.dto.user.UserSaveRequestDto;
 import com.skhuedin.skhuedin.social.SocialOauth;
+import com.skhuedin.skhuedin.yml.DataYamlRead;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -18,9 +20,11 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class KakaoOauth implements SocialOauth {
 
     private final RestTemplate restTemplate;
+    private final DataYamlRead dataYamlRead;
 
     public UserSaveRequestDto requestAccessToken(OAuthToken oauthToken) {
         UserSaveRequestDto user = null;
@@ -36,7 +40,7 @@ public class KakaoOauth implements SocialOauth {
 
         // Http 요청하기 - post 방식으로ㅡ 그리고 응답받음.
         ResponseEntity<String> response2 = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
+                dataYamlRead.getKakaoUrl(),
                 HttpMethod.POST,
                 kakaoProfileRequest2,
                 String.class

--- a/src/main/java/com/skhuedin/skhuedin/social/naver/NaverOauth.java
+++ b/src/main/java/com/skhuedin/skhuedin/social/naver/NaverOauth.java
@@ -6,6 +6,7 @@ import com.skhuedin.skhuedin.domain.Provider;
 import com.skhuedin.skhuedin.dto.user.UserSaveRequestDto;
 import com.skhuedin.skhuedin.social.SocialOauth;
 import com.skhuedin.skhuedin.social.kakao.OAuthToken;
+import com.skhuedin.skhuedin.yml.DataYamlRead;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -24,6 +25,7 @@ import java.util.UUID;
 public class NaverOauth implements SocialOauth {
 
     private final RestTemplate restTemplate;
+    private final DataYamlRead dataYamlRead;
 
     @Override
     public UserSaveRequestDto requestAccessToken(OAuthToken oAuthToken) {
@@ -38,7 +40,7 @@ public class NaverOauth implements SocialOauth {
 
         // Http 요청하기 - post 방식으로 ㅡ 그리고 응답받음.
         ResponseEntity<String> response = restTemplate.exchange(
-                "https://openapi.naver.com/v1/nid/me",
+                dataYamlRead.getNaver(),
                 HttpMethod.POST,
                 naverProfileRequest,
                 String.class

--- a/src/main/java/com/skhuedin/skhuedin/yml/DataYamlRead.java
+++ b/src/main/java/com/skhuedin/skhuedin/yml/DataYamlRead.java
@@ -1,0 +1,24 @@
+package com.skhuedin.skhuedin.yml;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Getter
+@Setter
+@Configuration
+//value를 통해 값이 있는 위치를 명시해준다.
+@PropertySource(value = "classpath:data.yml", factory = YamlPropertySourceFactory.class)
+@ConfigurationProperties(prefix = "my")
+public class DataYamlRead {
+
+    private String age;
+    private String kakao;
+    private String googleReqURL;
+    private String kakaoUrl;
+    private String naver;
+
+
+}

--- a/src/main/java/com/skhuedin/skhuedin/yml/YamlPropertySourceFactory.java
+++ b/src/main/java/com/skhuedin/skhuedin/yml/YamlPropertySourceFactory.java
@@ -1,0 +1,38 @@
+package com.skhuedin.skhuedin.yml;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+import org.springframework.lang.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Properties;
+
+//PropertySourceFactory를 상속받아 구현한다.
+public class YamlPropertySourceFactory implements PropertySourceFactory {
+
+    @Override
+    public PropertySource<?> createPropertySource(@Nullable String name, EncodedResource resource) throws IOException {
+        Properties propertiesFromYaml = loadYamlIntoProperties(resource);
+        String sourceName = name != null ? name : resource.getResource().getFilename();
+        return new PropertiesPropertySource(sourceName, propertiesFromYaml);
+    }
+
+    private Properties loadYamlIntoProperties(EncodedResource resource) throws FileNotFoundException {
+        try {
+            YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+            factory.setResources(resource.getResource());
+            factory.afterPropertiesSet();
+            return factory.getObject();
+        } catch (IllegalStateException e) {
+            // for ignoreResourceNotFound
+            Throwable cause = e.getCause();
+            if (cause instanceof FileNotFoundException)
+                throw (FileNotFoundException) e.getCause();
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/data.yml
+++ b/src/main/resources/data.yml
@@ -1,0 +1,6 @@
+my:
+  age: 300
+  kakao: 'b9de844ef665dda98917b7ec7b9d9a8b'
+  googleReqURL : "https://www.googleapis.com/userinfo/v2/me?access_token="
+  kakaoUrl : "https://kapi.kakao.com/v2/user/me"
+  naver : "https://openapi.naver.com/v1/nid/me"

--- a/src/main/resources/static/js/get.js
+++ b/src/main/resources/static/js/get.js
@@ -337,6 +337,20 @@ function defaultText() {
     return result;
 }
 
+function kakao2(){
+    var a ="";
 
+    //서버로 보낼 데이터 준비 : 파라미터로 만들기 . json 으로 만들기
+    $.ajax({
+        url: 'kakao'
+        , method: 'GET'
+        , async: false // 동기 방식을 위한 설정
+        , success: function (resp) {
+            a = resp["kakaoId"]
+
+        }
+    })
+    return a;
+}
 
 

--- a/src/main/resources/templates/contents/kakaoLogin.html
+++ b/src/main/resources/templates/contents/kakaoLogin.html
@@ -16,7 +16,6 @@
             <a id="kakao-login-btn"></a>
             <a href="http://developers.kakao.com/logout"></a>
             <script type="text/javascript">
-
                 Kakao.init('b9de844ef665dda98917b7ec7b9d9a8b');
                 Kakao.Auth.createLoginButton({
                     container: '#kakao-login-btn',
@@ -33,4 +32,7 @@
 </div>
 </body>
 </html>
+<script>
+
+</script>
 

--- a/src/test/java/com/skhuedin/skhuedin/yml/DataYamlReadTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/yml/DataYamlReadTest.java
@@ -1,0 +1,28 @@
+package com.skhuedin.skhuedin.yml;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class DataYamlReadTest {
+
+    @Autowired
+    DataYamlRead dataYamlRead;
+
+    @DisplayName("yml 에서 데이터를 잘 불러오는지 테스트")
+    @Test
+    void name() {
+        String age = dataYamlRead.getAge();
+
+        System.out.println("My age is " + age);
+        System.out.println(dataYamlRead.getKakao());
+        assertThat(age).isEqualTo("300");
+    }
+
+
+}


### PR DESCRIPTION
1) 중요한 정보는 yml 파일로 분리하여 저장한다.

![image](https://user-images.githubusercontent.com/26570275/120100108-e3ae8100-c179-11eb-9fd2-6eb66a34504b.png)

리소스 폴더에 data.yml 파일 생성 후

```java
my:
  age: 300
  kakao: 'b9de844ef665dda98917b7ec7b9d9a8b'
  googleReqURL : "https://www.googleapis.com/userinfo/v2/me?access_token="
  kakaoUrl : "https://kapi.kakao.com/v2/user/me"
  naver : "https://openapi.naver.com/v1/nid/me"

```

해당 값을 저장한다. 

스프링에서 yml 파일은 application.yml 밖에 인식이 안되기 때문에 생성한 yml 파일을 찾기위한 YamlPropertySourceFactory 를 생성했다.
