### PR TITLE
[TEST] AdminControllerApi 분리 / category Test 전체 로직 점검

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,11 @@ dependencies {
     implementation 'io.swagger:swagger-models:1.5.21'
 
     compileOnly 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtime 'io.jsonwebtoken:jjwt-impl:0.11.2',

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
@@ -33,7 +33,6 @@ public class AdminMainController {
     public ModelAndView postsDetail() {
         ModelAndView modelAndView = new ModelAndView();
         modelAndView.setViewName("admin/posts-detail");
-        modelAndView.setViewName("admin/posts-detail");
         return modelAndView;
     }
 

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminCategoryApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminCategoryApiController.java
@@ -25,7 +25,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminCategoryApiController {
     private final CategoryService categoryService;
 
-//    @MyRole(role = Role.ADMIN)
+    //    @MyRole(role = Role.ADMIN)
+    @GetMapping("categories")
+    public ResponseEntity<? extends BasicResponse> categories() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(categoryService.findAll()));
+    }
+
+    //    @MyRole(role = Role.ADMIN)
     @GetMapping("category")
     public ResponseEntity<? extends BasicResponse> getCategory(
             Pageable pageable,
@@ -43,7 +50,7 @@ public class AdminCategoryApiController {
         }
     }
 
-//    @MyRole(role = Role.ADMIN)
+    //    @MyRole(role = Role.ADMIN)
     @GetMapping("category/{categoryId}")
     public ResponseEntity<? extends BasicResponse> getCategory(@PathVariable("categoryId") Long id) {
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminPostsApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminPostsApiController.java
@@ -1,0 +1,64 @@
+package com.skhuedin.skhuedin.controller.admin.api;
+
+import com.skhuedin.skhuedin.controller.response.BasicResponse;
+import com.skhuedin.skhuedin.controller.response.CommonResponse;
+import com.skhuedin.skhuedin.dto.posts.PostsAdminUpdateRequestDto;
+import com.skhuedin.skhuedin.infra.MyRole;
+import com.skhuedin.skhuedin.infra.Role;
+import com.skhuedin.skhuedin.service.CategoryService;
+import com.skhuedin.skhuedin.service.PostsService;
+import com.skhuedin.skhuedin.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminPostsApiController {
+
+    private final PostsService postsService;
+
+    //    @MyRole(role = Role.ADMIN)
+    @GetMapping("posts")
+    public ResponseEntity<? extends BasicResponse> getPosts(
+            Pageable pageable,
+            @RequestParam(name = "category", defaultValue = "") String categoryName,
+            @RequestParam(name = "username", defaultValue = "") String username) {
+
+        if (categoryName.isEmpty() && !username.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(new CommonResponse<>(postsService.findByUserName(pageable, username)));
+        } else if (!categoryName.isEmpty() && username.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(new CommonResponse<>(postsService.findByCategoryName(pageable, categoryName)));
+        } else {
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(new CommonResponse<>(postsService.findAll(pageable)));
+        }
+    }
+
+    //    @MyRole(role = Role.ADMIN)
+    @GetMapping("posts/{postsId}")
+    public ResponseEntity<? extends BasicResponse> getPosts(@PathVariable("postsId") Long id) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(postsService.findByIdByAdmin(id)));
+    }
+
+    //    @MyRole(role = Role.ADMIN)
+    @PutMapping("posts/{postsId}")
+    public ResponseEntity<? extends BasicResponse> updatePosts(@RequestBody PostsAdminUpdateRequestDto requestDto) {
+        postsService.update(requestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminQuestionsApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminQuestionsApiController.java
@@ -2,10 +2,6 @@ package com.skhuedin.skhuedin.controller.admin.api;
 
 import com.skhuedin.skhuedin.controller.response.BasicResponse;
 import com.skhuedin.skhuedin.controller.response.CommonResponse;
-import com.skhuedin.skhuedin.dto.posts.PostsAdminUpdateRequestDto;
-import com.skhuedin.skhuedin.infra.MyRole;
-import com.skhuedin.skhuedin.infra.Role;
-import com.skhuedin.skhuedin.service.CategoryService;
 import com.skhuedin.skhuedin.service.PostsService;
 import com.skhuedin.skhuedin.service.QuestionService;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,51 +19,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
 @Slf4j
-public class AdminApiController {
+public class AdminQuestionsApiController {
 
     private final PostsService postsService;
-    private final CategoryService categoryService;
     private final QuestionService questionService;
-
-    //    @MyRole(role = Role.ADMIN)
-    @GetMapping("posts")
-    public ResponseEntity<? extends BasicResponse> getPosts(
-            Pageable pageable,
-            @RequestParam(name = "category", defaultValue = "") String categoryName,
-            @RequestParam(name = "username", defaultValue = "") String username) {
-
-        if (categoryName.isEmpty() && !username.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(new CommonResponse<>(postsService.findByUserName(pageable, username)));
-        } else if (!categoryName.isEmpty() && username.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(new CommonResponse<>(postsService.findByCategoryName(pageable, categoryName)));
-        } else {
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(new CommonResponse<>(postsService.findAll(pageable)));
-        }
-    }
-
-    //    @MyRole(role = Role.ADMIN)
-    @GetMapping("posts/{postsId}")
-    public ResponseEntity<? extends BasicResponse> getPosts(@PathVariable("postsId") Long id) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new CommonResponse<>(postsService.findByIdByAdmin(id)));
-    }
-
-    //    @MyRole(role = Role.ADMIN)
-    @GetMapping("categories")
-    public ResponseEntity<? extends BasicResponse> categories() {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new CommonResponse<>(categoryService.findAll()));
-    }
-
-    //    @MyRole(role = Role.ADMIN)
-    @PutMapping("posts/{postsId}")
-    public ResponseEntity<? extends BasicResponse> updatePosts(@RequestBody PostsAdminUpdateRequestDto requestDto) {
-        postsService.update(requestDto);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
 
     //    @MyRole(role = Role.ADMIN)
     @GetMapping("questions")

--- a/src/main/java/com/skhuedin/skhuedin/service/CategoryService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/CategoryService.java
@@ -1,10 +1,8 @@
 package com.skhuedin.skhuedin.service;
 
 import com.skhuedin.skhuedin.domain.Category;
-import com.skhuedin.skhuedin.domain.User;
 import com.skhuedin.skhuedin.dto.category.CategoryMainResponseDto;
 import com.skhuedin.skhuedin.dto.category.CategoryRequestDto;
-import com.skhuedin.skhuedin.dto.user.UserMainResponseDto;
 import com.skhuedin.skhuedin.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,8 +22,8 @@ public class CategoryService {
     private final PostsService postsService;
 
     @Transactional
-    public void save(CategoryRequestDto requestDto) {
-        categoryRepository.save(requestDto.toEntity());
+    public Long save(CategoryRequestDto requestDto) {
+        return categoryRepository.save(requestDto.toEntity()).getId();
     }
 
     public List<CategoryMainResponseDto> findAll() {
@@ -40,6 +38,10 @@ public class CategoryService {
                 .map(category -> findByPost(new CategoryMainResponseDto(category)));
     }
 
+    public CategoryMainResponseDto findById(Long id) {
+        return new CategoryMainResponseDto(categoryRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("해당 category 존재하지 않습니다. id=" + id)));
+    }
 
     public List<CategoryMainResponseDto> findByWeight() {
         return categoryRepository.findByWeight()

--- a/src/test/java/com/skhuedin/skhuedin/controller/admin/AdminMainControllerTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/controller/admin/AdminMainControllerTest.java
@@ -24,7 +24,7 @@ class AdminMainControllerTest {
                 .build();
     }
 
-    @DisplayName("어드민 메인 페이 로딩 ")
+    @DisplayName("어드민 메인 페이 로딩")
     @Test
     void main_page_true() throws Exception {
         this.mockMvc.perform(get("/admin"))
@@ -33,7 +33,7 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("게시글 관리 페이지 로딩 ")
+    @DisplayName("게시글 관리 페이지 로딩")
     @Test
     void posts_page_true() throws Exception {
         this.mockMvc.perform(get("/admin/posts"))
@@ -69,7 +69,7 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("'회원 관리 페이지 로딩 ")
+    @DisplayName("회원 관리 페이지 로딩")
     @Test
     void user_page_true() throws Exception {
         this.mockMvc.perform(get("/admin/users"))
@@ -78,7 +78,7 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("'회원 수정 페이지 로딩 ")
+    @DisplayName("회원 수정 페이지 로딩")
     @Test
     void user_detail_page_true() throws Exception {
         this.mockMvc.perform(get("/admin/users/detail"))
@@ -87,7 +87,7 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("'카테고리 관리 페이지 로딩 ")
+    @DisplayName("카테고리 관리 페이지 로딩")
     @Test
     void category_page_true() throws Exception {
         this.mockMvc.perform(get("/admin/category"))
@@ -96,7 +96,7 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("'카테고리 관리 수정 페이지 로딩 ")
+    @DisplayName("카테고리 관리 수정 페이지 로딩")
     @Test
     void category_detail_page_true() throws Exception {
         this.mockMvc.perform(get("/admin/category/detail"))

--- a/src/test/java/com/skhuedin/skhuedin/controller/admin/AdminMainControllerTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/controller/admin/AdminMainControllerTest.java
@@ -51,6 +51,24 @@ class AdminMainControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @DisplayName("질문 관리 페이지 로딩")
+    @Test
+    void question_page_true() throws Exception {
+        this.mockMvc.perform(get("/admin/question"))
+                .andDo(print())
+                .andExpect(view().name("admin/question"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("질문 관리 수정 페이지 로딩")
+    @Test
+    void question_detail_page_true() throws Exception {
+        this.mockMvc.perform(get("/admin/question/detail"))
+                .andDo(print())
+                .andExpect(view().name("admin/question-detail"))
+                .andExpect(status().isOk());
+    }
+
     @DisplayName("'회원 관리 페이지 로딩 ")
     @Test
     void user_page_true() throws Exception {
@@ -66,6 +84,24 @@ class AdminMainControllerTest {
         this.mockMvc.perform(get("/admin/users/detail"))
                 .andDo(print())
                 .andExpect(view().name("admin/users-detail"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("'카테고리 관리 페이지 로딩 ")
+    @Test
+    void category_page_true() throws Exception {
+        this.mockMvc.perform(get("/admin/category"))
+                .andDo(print())
+                .andExpect(view().name("admin/category"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("'카테고리 관리 수정 페이지 로딩 ")
+    @Test
+    void category_detail_page_true() throws Exception {
+        this.mockMvc.perform(get("/admin/category/detail"))
+                .andDo(print())
+                .andExpect(view().name("admin/category-detail"))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/skhuedin/skhuedin/controller/admin/api/AdminUserApiControllerTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/controller/admin/api/AdminUserApiControllerTest.java
@@ -1,58 +1,68 @@
 package com.skhuedin.skhuedin.controller.admin.api;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Sql("/truncate.sql")
 @SpringBootTest
 class AdminUserApiControllerTest {
     private MockMvc mockMvc;
-
-    @BeforeEach
-    void setUp(WebApplicationContext webApplicationContext) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .build();
-    }
-
-    @DisplayName("user 검색 없이 전체 조회")
-    @Test
-    void user_find_role() throws Exception {
-        //given 어떤 값이 주어지고
-
-        //when 무엇을 했을 때 then 어떤 값을 원한다.
-        mockMvc.perform(get("/api/admin/users?page=0&size=10")
-                .param("role", "ADMIN")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print())
-                .andReturn();
-    }
-
-    @DisplayName("category 전체 조회")
-    @Test
-    void category_find() throws Exception {
-        //given 어떤 값이 주어지고
-
-        //when 무엇을 했을 때 then 어떤 값을 원한다.
-        mockMvc.perform(get("/api/admin/category?page=0&size=10")
-                .param("role", "ADMIN")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andDo(print())
-                .andReturn();
-
-    }
+//
+//    @BeforeEach
+//    void setUp(WebApplicationContext webApplicationContext) {
+//        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+//                .build();
+//    }
+//
+//    @DisplayName("user 검색 없이 전체 조회")
+//    @Test
+//    void user_find_role() throws Exception {
+//        //given 어떤 값이 주어지고
+//
+//        //when 무엇을 했을 때 then 어떤 값을 원한다.
+//        mockMvc.perform(get("/api/admin/users?page=0&size=10")
+//                .param("role", "ADMIN")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andDo(print())
+//                .andReturn();
+//    }
+//
+//
+//    @DisplayName("'/user'로 post요청")
+//    @Test
+//    void userList() throws Exception {
+//
+//        //given 어떤 값이 주어지고
+//        String token = getUser();
+//
+//        //when 무엇을 했을 때
+//        MockHttpServletRequestBuilder requestBuilder = post("/user")
+//                .header("Authorization", "Bearer " + token);
+//
+//        //then 어떤 값을 원한다.
+//        MvcResult result = this.mockMvc.perform(requestBuilder)
+//                .andDo(print())
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$..['role']").exists())
+//                .andReturn();
+//
+//
+//        @DisplayName("category 전체 조회")
+//    @Test
+//    void category_find() throws Exception {
+//        //given 어떤 값이 주어지고
+//
+//        //when 무엇을 했을 때 then 어떤 값을 원한다.
+//        mockMvc.perform(get("/api/admin/category?page=0&size=10")
+//                .param("role", "ADMIN")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andDo(print())
+//                .andReturn();
+//
+//    }
 }

--- a/src/test/java/com/skhuedin/skhuedin/controller/admin/api/CategoryAdminApiControllerTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/controller/admin/api/CategoryAdminApiControllerTest.java
@@ -1,23 +1,205 @@
 package com.skhuedin.skhuedin.controller.admin.api;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skhuedin.skhuedin.dto.category.CategoryRequestDto;
+import com.skhuedin.skhuedin.service.CategoryService;
+import com.skhuedin.skhuedin.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @Sql("/truncate.sql")
 @SpringBootTest
 class CategoryAdminApiControllerTest {
+
+    private MockMvc mockMvc;
+    private CategoryRequestDto category;
+    private int saveId;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    CategoryService categoryService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .build();
+
+        category = CategoryRequestDto.builder()
+                .name("test1")
+                .weight(4L)
+                .build();
+        saveId = Math.toIntExact(categoryService.save(category));
+
+        category = CategoryRequestDto.builder()
+                .name("test2")
+                .weight(4L)
+                .build();
+        categoryService.save(category);
+    }
+
+    @DisplayName("category findAll")
+    @Test
+    void categories() throws Exception {
+
+        this.mockMvc.perform(get("/api/admin/categories"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$..data[0].name").value("test1"))
+                .andExpect(jsonPath("$..data[1].name").value("test2"));
+    }
+
+    @DisplayName("카테고리 전체 조회 cmd 없이 요청(id 기준)")
+    @Test
+    void categoryList_paging_sortById_true() throws Exception {
+
+        //given & when
+        MockHttpServletRequestBuilder requestBuilder = get("/api/admin/category")
+                .params(getPage());
+
+        //then 어떤 값을 원한다.
+        MvcResult result = this.mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 전체 조회 가중치 정렬 기준으로 요청")
+    @Test
+    void categoryList_paging_sortByWeight_true() throws Exception {
+
+        //given & when
+        MockHttpServletRequestBuilder requestBuilder = get("/api/admin/category")
+                .param("cmd", String.valueOf(1))
+                .params(getPage());
+
+        //then 어떤 값을 원한다.
+        MvcResult result = this.mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..content[0].weight").value(4))
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 전체 조회 생성일 정렬 기준으로 요청")
+    @Test
+    void categoryList_paging_sortByCreateDate_true() throws Exception {
+
+        //given & when
+        MockHttpServletRequestBuilder requestBuilder = get("/api/admin/category")
+                .param("cmd", String.valueOf(2))
+                .params(getPage());
+
+        //then 어떤 값을 원한다.
+        MvcResult result = this.mockMvc.perform(requestBuilder)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 단건 조회")
+    @Test
+    void findById_true() throws Exception {
+
+        //given & when & then
+        MvcResult result = this.mockMvc.perform(get("/api/admin/category/" + saveId))
+                .andDo(print())
+                .andExpect(jsonPath("$..id").value(saveId))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 가중치 증가")
+    @Test
+    void weight_up_true() throws Exception {
+        //given
+        int weight = Math.toIntExact(category.getWeight()) + 1;
+
+        //when
+        MvcResult result = this.mockMvc.perform(get("/api/admin/category/up/" + saveId))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andReturn();
+        //then
+        MvcResult result2 = this.mockMvc.perform(get("/api/admin/category/" + saveId))
+                .andDo(print())
+                .andExpect(jsonPath("$..weight").value(weight))
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 가중치 감소")
+    @Test
+    void weight_down_true() throws Exception {
+        //given
+        int weight = Math.toIntExact(category.getWeight()) - 1;
+
+        //when
+        MvcResult result = this.mockMvc.perform(get("/api/admin/category/down/" + saveId))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andReturn();
+        //then
+        MvcResult result2 = this.mockMvc.perform(get("/api/admin/category/" + saveId))
+                .andDo(print())
+                .andExpect(jsonPath("$..weight").value(weight))
+                .andReturn();
+    }
+
+    @DisplayName("카테고리 생성 성공")
+    @Test
+    void category_create_true() throws Exception {
+        //given
+        String content = objectMapper.writeValueAsString(new CategoryRequestDto("테스트", 4L));
+
+        //when & then
+        this.mockMvc.perform(post("/api/admin/category")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("카테고리 삭제")
+    @Test
+    void category_delete_true() throws Exception {
+        //given
+        this.mockMvc.perform(delete("/api/admin/category/" + saveId))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    MultiValueMap<String, String> getPage() {
+
+        MultiValueMap<String, String> requestParam = new LinkedMultiValueMap<>();
+        requestParam.add("page", "0");
+        requestParam.add("size", "10");
+
+        return requestParam;
+    }
 }

--- a/src/test/java/com/skhuedin/skhuedin/service/CategoryServiceTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/service/CategoryServiceTest.java
@@ -1,8 +1,166 @@
 package com.skhuedin.skhuedin.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.skhuedin.skhuedin.domain.Category;
+import com.skhuedin.skhuedin.dto.category.CategoryMainResponseDto;
+import com.skhuedin.skhuedin.dto.category.CategoryRequestDto;
+import com.skhuedin.skhuedin.repository.CategoryRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.jdbc.Sql;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Sql("/truncate.sql")
+@SpringBootTest
 class CategoryServiceTest {
 
+    @Autowired
+    CategoryRepository categoryRepository;
 
+    @Autowired
+    CategoryService categoryService;
+
+    Category category;
+
+    @BeforeEach
+    void beforeEach() {
+        category = Category.builder()
+                .name("x")
+                .weight(4L)
+                .build();
+
+        categoryRepository.save(category);
+    }
+
+    @DisplayName("category DTO 를 받아 저장하는 로직")
+    @Test
+    void save() {
+        //given 어떤 값이 주어지고
+        CategoryRequestDto requestDto = generateCategory();
+        Long saveId = categoryRepository.save(requestDto.toEntity()).getId();
+
+        //when 무엇을 했을 때
+        CategoryMainResponseDto responseDto = categoryService.findById(saveId);
+
+        //then 어떤 값을 원한다.
+        assertAll(
+                () -> assertEquals(saveId, responseDto.getId()),
+                () -> assertEquals(requestDto.getName(), responseDto.getName()),
+                () -> assertEquals(requestDto.getWeight(), responseDto.getWeight())
+        );
+    }
+
+    @DisplayName("category 를 조건 없이 전체 조회할 때")
+    @Test
+    void findAll() {
+        //given 어떤 값이 주어지고
+        CategoryRequestDto requestDto = generateCategory();
+        Long saveId = categoryRepository.save(requestDto.toEntity()).getId();
+
+        //when 무엇을 했을 때
+        List<CategoryMainResponseDto> list = categoryService.findAll();
+
+        //then 어떤 값을 원한다.
+        assertNotNull(list);
+    }
+
+    @DisplayName("category 를 findAll_paging 를 하여 전체 조회할 때")
+    @Test
+    void findAll_paging() {
+        //given 어떤 값이 주어지고
+        Pageable pageable = PageRequest.of(0, 10);
+
+        CategoryRequestDto requestDto = generateCategory();
+        Long saveId = categoryRepository.save(requestDto.toEntity()).getId();
+
+        //when 무엇을 했을 때
+        Page<CategoryMainResponseDto> list = categoryService.findAll(pageable);
+
+        //then 어떤 값을 원한다.
+        assertNotNull(list);
+    }
+
+    @DisplayName("category 단건 조회")
+    @Test
+    void findById() {
+        //given 어떤 값이 주어지고
+        CategoryRequestDto requestDto = generateCategory();
+        Long saveId = categoryRepository.save(requestDto.toEntity()).getId();
+
+        //when 무엇을 했을 때
+        CategoryMainResponseDto category = categoryService.findById(saveId);
+
+        //then 어떤 값을 원한다.
+        assertAll(
+                () -> assertEquals(saveId, category.getId()),
+                () -> assertEquals(requestDto.getName(), category.getName()),
+                () -> assertEquals(requestDto.getWeight(), category.getWeight())
+        );
+    }
+
+    @DisplayName("가중치 증가 테스트")
+    @Test
+    void addWeight() {
+        //given 어떤 값이 주어지고
+        Long weight = category.getWeight();
+
+        //when 무엇을 했을 때
+        category.addWeight();
+        category.addWeight();
+
+        //then 어떤 값을 원한다.
+        assertEquals(category.getWeight(), weight + 2L);
+    }
+
+    @DisplayName("가중치 감소 테스트")
+    @Test
+    void subtractWeight() {
+        //given 어떤 값이 주어지고
+        Long weight = category.getWeight();
+
+        //when 무엇을 했을 때
+        category.subtractWeight();
+        category.subtractWeight();
+
+        //then 어떤 값을 원한다.
+        assertEquals(category.getWeight(), weight - 2L);
+    }
+
+    @DisplayName("삭제가 잘 되는지 테스트")
+    @Test
+    void delete() {
+        //given 어떤 값이 주어지고
+        CategoryRequestDto requestDto = generateCategory();
+        Long saveId = categoryRepository.save(requestDto.toEntity()).getId();
+
+        //when 무엇을 했을 때
+        categoryService.delete(saveId);
+
+        //then 어떤 값을 원한다.
+        assertThrows(IllegalArgumentException.class, () ->
+                categoryService.findById(saveId)
+        );
+    }
+
+    @AfterEach
+    void afterEach() {
+        categoryRepository.deleteAll();
+    }
+
+    private CategoryRequestDto generateCategory() {
+        return CategoryRequestDto.builder()
+                .name("자기주도개발")
+                .weight(6L)
+                .build();
+    }
 }


### PR DESCRIPTION
#115 

## 1) 무분별하게 합쳐 있던 AdminControllerApi 를 도메인에 맞추어 분리했습니다. 
![image](https://user-images.githubusercontent.com/26570275/121872313-1642a700-cd40-11eb-8c91-c886189246bb.png)


## 2) page 전환되는 controller 중 누락된 테스트가 있어 추가했습니다. 
![image](https://user-images.githubusercontent.com/26570275/121871967-b3511000-cd3f-11eb-8cfb-03d42d745eeb.png)


## 3) category 의 service 부분 test code 추가했습니다.
![image](https://user-images.githubusercontent.com/26570275/121871667-548b9680-cd3f-11eb-85df-5cb549d8f7ee.png)

## 3) category 의 controller 부분 test code 새로 작성했습니다.
![image](https://user-images.githubusercontent.com/26570275/121871595-4473b700-cd3f-11eb-901b-ef31f9f84358.png)
