### PR TITLE
[FEAT] 긴 길이의 문자열 저장을 위한 content 필드 수정

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/domain/Posts.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Posts.java
@@ -33,6 +33,7 @@ public class Posts extends BaseEntity {
 
     private String title;
 
+    @Column(length = 50000)
     private String content;
 
     private Boolean deleteStatus;

--- a/src/main/java/com/skhuedin/skhuedin/dto/posts/PostsSaveRequestDto.java
+++ b/src/main/java/com/skhuedin/skhuedin/dto/posts/PostsSaveRequestDto.java
@@ -21,7 +21,7 @@ public class PostsSaveRequestDto {
     @Size(max = 30, message = "title의 길이는 30을 넘을 수 없습니다.")
     private String title;
 
-    @Size(max = 5000, message = "content의 길이는 5000을 넘을 수 없습니다.")
+    @Size(max = 50000, message = "content의 길이는 50000을 넘을 수 없습니다.")
     private String content;
 
     @Builder

--- a/src/test/java/com/skhuedin/skhuedin/dto/posts/PostsSaveRequestDtoTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/dto/posts/PostsSaveRequestDtoTest.java
@@ -23,7 +23,7 @@ class PostsSaveRequestDtoTest {
 
         // given
         StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < 5001; i++) {
+        for (int i = 0; i < 50001; i++) {
             stringBuilder.append(i);
         }
 
@@ -36,7 +36,7 @@ class PostsSaveRequestDtoTest {
         ArrayList<String> errorMessages = new ArrayList<>();
         errorMessages.add("blog의 id는 null이 될 수 없습니다.");
         errorMessages.add("title이 비어 있습니다.");
-        errorMessages.add("content의 길이는 5000을 넘을 수 없습니다.");
+        errorMessages.add("content의 길이는 50000을 넘을 수 없습니다.");
         errorMessages.add("title의 길이는 15를 넘을 수 없습니다.");
 
         // when

--- a/src/test/java/com/skhuedin/skhuedin/repository/PostsRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/PostsRepositoryTest.java
@@ -230,7 +230,33 @@ class PostsRepositoryTest {
         // then
         assertEquals(count, 10);
     }
-    
+
+    @Test
+    @DisplayName("최대 길이의 content를 저장하는 테스트")
+    void save_max_content() {
+
+        // given
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 50000; i++) {
+            stringBuilder.append("+");
+        }
+
+        Posts posts = Posts.builder()
+                .blog(blog)
+                .title("책장의 게시글")
+                .content(stringBuilder.toString())
+                .category(category1)
+                .build();
+
+        Posts save = postsRepository.save(posts);
+
+        // when
+        Posts findPosts = postsRepository.findById(save.getId()).get();
+
+        // then
+        assertEquals(findPosts.getContent().length(), 50000);
+    }
+
     Posts generatePosts(int index, Category category) {
         return Posts.builder()
                 .blog(blog)


### PR DESCRIPTION
#179 

content 필드의 최대 저장 길이를 50000으로 늘렸습니다! 

관련 적용을 위해 간단히 정리한 자료를 첨부할게요! 아직 부족한 내용이 많아 간단히 참고만 해주세용

[[JPA] 긴 길이의 문자열 저장하기](https://hyeonic.tistory.com/208)