### PR TITLE
[FEAT] banner 등록 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
@@ -94,4 +94,14 @@ public class AdminMainController {
         modelAndView.setViewName("admin/blogs");
         return modelAndView;
     }
+
+    @GetMapping("banners")
+    public String banners() {
+        return "admin/banner/banners";
+    }
+
+    @GetMapping("banner/new")
+    public String newBanner() {
+        return "admin/banner/banner-form";
+    }
 }

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/AdminMainController.java
@@ -1,5 +1,6 @@
 package com.skhuedin.skhuedin.controller.admin;
 
+import com.skhuedin.skhuedin.service.BannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,8 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping("/admin")
 @RequiredArgsConstructor
 public class AdminMainController {
+
+    private final BannerService bannerService;
 
     @GetMapping
     public ModelAndView main() {
@@ -100,8 +103,13 @@ public class AdminMainController {
         return "admin/banner/banners";
     }
 
-    @GetMapping("banner/new")
+    @GetMapping("banners/new")
     public String newBanner() {
         return "admin/banner/banner-form";
+    }
+
+    @GetMapping("banners/update")
+    public String updateBanner() {
+        return "admin/banner/banner-update-form";
     }
 }

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminBannerApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/api/AdminBannerApiController.java
@@ -11,9 +11,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +26,7 @@ import java.io.IOException;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-public class BannerApiController {
+public class AdminBannerApiController {
 
     private final BannerService bannerService;
 
@@ -42,5 +45,28 @@ public class BannerApiController {
     public ResponseEntity<? extends BasicResponse> findAll(Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new CommonResponse<>(bannerService.findAll(pageable)));
+    }
+
+    @MyRole(role = Role.ADMIN)
+    @GetMapping("banners/{bannerId}")
+    public ResponseEntity<? extends BasicResponse> findById(@PathVariable Long bannerId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(bannerService.findById(bannerId)));
+    }
+
+    @MyRole(role = Role.ADMIN)
+    @PutMapping("banners/{bannerId}")
+    public ResponseEntity<? extends BasicResponse> update(@PathVariable Long bannerId,
+                                                          @ModelAttribute BannerForm bannerForm) throws IOException {
+        bannerService.update(bannerId, bannerForm);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(bannerService.findById(bannerId)));
+    }
+
+    @MyRole(role = Role.ADMIN)
+    @DeleteMapping("banners/{bannerId}")
+    public ResponseEntity<? extends BasicResponse> delete(@PathVariable Long bannerId) {
+        bannerService.delete(bannerId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/api/BannerApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/api/BannerApiController.java
@@ -1,0 +1,46 @@
+package com.skhuedin.skhuedin.controller.admin.api;
+
+import com.skhuedin.skhuedin.controller.admin.form.BannerForm;
+import com.skhuedin.skhuedin.controller.response.BasicResponse;
+import com.skhuedin.skhuedin.controller.response.CommonResponse;
+import com.skhuedin.skhuedin.infra.MyRole;
+import com.skhuedin.skhuedin.infra.Role;
+import com.skhuedin.skhuedin.service.BannerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class BannerApiController {
+
+    private final BannerService bannerService;
+
+    @MyRole(role = Role.ADMIN)
+    @PostMapping("banners")
+    public ResponseEntity<? extends BasicResponse> save(@ModelAttribute BannerForm bannerForm) throws IOException {
+
+        Long saveId = bannerService.save(bannerForm);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CommonResponse<>(bannerService.findById(saveId)));
+    }
+
+    @MyRole(role = Role.ADMIN)
+    @GetMapping("banners")
+    public ResponseEntity<? extends BasicResponse> findAll(Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(bannerService.findAll(pageable)));
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/form/BannerForm.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/form/BannerForm.java
@@ -1,14 +1,24 @@
 package com.skhuedin.skhuedin.controller.admin.form;
 
+import com.skhuedin.skhuedin.domain.Banner;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class BannerForm {
 
     private String title;
     private String content;
+    private Integer weight;
     private MultipartFile imageFile;
+
+    public BannerForm(Banner banner) {
+        this.title = banner.getTitle();
+        this.content = banner.getContent();
+        this.weight = banner.getWeight();
+    }
 }

--- a/src/main/java/com/skhuedin/skhuedin/controller/admin/form/BannerForm.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/admin/form/BannerForm.java
@@ -1,0 +1,14 @@
+package com.skhuedin.skhuedin.controller.admin.form;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class BannerForm {
+
+    private String title;
+    private String content;
+    private MultipartFile imageFile;
+}

--- a/src/main/java/com/skhuedin/skhuedin/controller/api/BannerApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/api/BannerApiController.java
@@ -1,0 +1,37 @@
+package com.skhuedin.skhuedin.controller.api;
+
+import com.skhuedin.skhuedin.controller.response.BasicResponse;
+import com.skhuedin.skhuedin.controller.response.CommonResponse;
+import com.skhuedin.skhuedin.file.FileStore;
+import com.skhuedin.skhuedin.service.BannerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.MalformedURLException;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class BannerApiController {
+
+    private final BannerService bannerService;
+    private final FileStore fileStore;
+
+    @GetMapping("banners")
+    public ResponseEntity<? extends BasicResponse> findAll() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new CommonResponse<>(bannerService.findAll()));
+    }
+
+    @GetMapping("banners/images/{storeFileName}")
+    public Resource downloadImage(@PathVariable String storeFileName) throws MalformedURLException {
+        return new UrlResource("file:" + fileStore.getFullPath(storeFileName));
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/domain/Banner.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Banner.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -18,19 +19,32 @@ public class Banner extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "banner_id")
     private Long id;
 
     private String title;
 
     private String content;
 
+    private Integer weight;
+
     @Embedded
     private UploadFile uploadFile;
 
     @Builder
-    public Banner(String title, String content, UploadFile uploadFile) {
+    public Banner(String title, String content, Integer weight, UploadFile uploadFile) {
         this.title = title;
         this.content = content;
+        this.weight = weight;
         this.uploadFile = uploadFile;
+    }
+
+    public void updateBanner(Banner banner) {
+        this.title = banner.title;
+        this.content = banner.content;
+        this.weight = banner.weight;
+        if (banner.getUploadFile() != null) {
+            this.uploadFile = banner.getUploadFile();
+        }
     }
 }

--- a/src/main/java/com/skhuedin/skhuedin/domain/Banner.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Banner.java
@@ -1,0 +1,36 @@
+package com.skhuedin.skhuedin.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @Embedded
+    private UploadFile uploadFile;
+
+    @Builder
+    public Banner(String title, String content, UploadFile uploadFile) {
+        this.title = title;
+        this.content = content;
+        this.uploadFile = uploadFile;
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/domain/UploadFile.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/UploadFile.java
@@ -1,0 +1,23 @@
+package com.skhuedin.skhuedin.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Embeddable;
+
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UploadFile {
+
+    private String uploadFileName;
+    private String storeFileName;
+
+    public UploadFile(String uploadFileName, String storeFileName) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileName = storeFileName;
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/dto/banner/BannerAdminMainResponseDto.java
+++ b/src/main/java/com/skhuedin/skhuedin/dto/banner/BannerAdminMainResponseDto.java
@@ -11,6 +11,7 @@ public class BannerAdminMainResponseDto {
     private final Long id;
     private final String title;
     private final String content;
+    private final Integer weight;
     private final String createdDate;
     private final String lastModifiedDate;
 
@@ -18,6 +19,7 @@ public class BannerAdminMainResponseDto {
         this.id = banner.getId();
         this.title = banner.getTitle();
         this.content = banner.getContent();
+        this.weight = banner.getWeight();
         this.createdDate = banner.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         this.lastModifiedDate = banner.getLastModifiedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }

--- a/src/main/java/com/skhuedin/skhuedin/dto/banner/BannerAdminMainResponseDto.java
+++ b/src/main/java/com/skhuedin/skhuedin/dto/banner/BannerAdminMainResponseDto.java
@@ -1,0 +1,24 @@
+package com.skhuedin.skhuedin.dto.banner;
+
+import com.skhuedin.skhuedin.domain.Banner;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class BannerAdminMainResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final String createdDate;
+    private final String lastModifiedDate;
+
+    public BannerAdminMainResponseDto(Banner banner) {
+        this.id = banner.getId();
+        this.title = banner.getTitle();
+        this.content = banner.getContent();
+        this.createdDate = banner.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        this.lastModifiedDate = banner.getLastModifiedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
+++ b/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
@@ -32,6 +32,11 @@ public class FileStore {
         return new UploadFile(originalFilename, storeFileName);
     }
 
+    public void removeFile(String filename) {
+        File file = new File(getFullPath(filename));
+        file.delete();
+    }
+
     private String createStoreFileName(String originalFileName) {
         String ext = extractExt(originalFileName);
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
+++ b/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
@@ -1,0 +1,46 @@
+package com.skhuedin.skhuedin.file;
+
+import com.skhuedin.skhuedin.domain.UploadFile;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class FileStore {
+
+    @Value("${file.dir}")
+    private String fileDir;
+
+    public String getFullPath(String filename) {
+        return fileDir + filename;
+    }
+
+    public UploadFile storeFile(MultipartFile multipartFile) throws IOException {
+        if (multipartFile.isEmpty()) {
+            return null;
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename();
+
+        // 서버에 저장하는 파일명
+        String storeFileName = createStoreFileName(originalFilename);
+        multipartFile.transferTo(new File(getFullPath(storeFileName)));
+        return new UploadFile(originalFilename, storeFileName);
+    }
+
+    private String createStoreFileName(String originalFileName) {
+        String ext = extractExt(originalFileName);
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + ext;
+    }
+
+    // 확장자를 꺼내는 부분
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf("."); // 위치를 가져옴
+        return originalFilename.substring(pos + 1); // . 이후 내용을 뽑아서 반환
+    }
+}

--- a/src/main/java/com/skhuedin/skhuedin/repository/BannerRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/BannerRepository.java
@@ -1,0 +1,7 @@
+package com.skhuedin.skhuedin.repository;
+
+import com.skhuedin.skhuedin.domain.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/com/skhuedin/skhuedin/repository/BannerRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/BannerRepository.java
@@ -1,7 +1,22 @@
 package com.skhuedin.skhuedin.repository;
 
 import com.skhuedin.skhuedin.domain.Banner;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    @Query("select b " +
+            "from Banner b " +
+            "order by b.weight DESC ")
+    List<Banner> findAll();
+
+    @Query("select b " +
+            "from Banner b " +
+            "order by b.weight DESC ")
+    Page<Banner> findAll(Pageable pageable);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/BannerService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/BannerService.java
@@ -1,0 +1,48 @@
+package com.skhuedin.skhuedin.service;
+
+import com.skhuedin.skhuedin.controller.admin.form.BannerForm;
+import com.skhuedin.skhuedin.domain.Banner;
+import com.skhuedin.skhuedin.domain.UploadFile;
+import com.skhuedin.skhuedin.dto.banner.BannerAdminMainResponseDto;
+import com.skhuedin.skhuedin.file.FileStore;
+import com.skhuedin.skhuedin.repository.BannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+    private final FileStore fileStore;
+
+    @Transactional
+    public Long save(BannerForm bannerForm) throws IOException {
+        UploadFile uploadFile = fileStore.storeFile(bannerForm.getImageFile());
+
+        Banner banner = Banner.builder()
+                .title(bannerForm.getTitle())
+                .content(bannerForm.getContent())
+                .uploadFile(uploadFile)
+                .build();
+
+        return bannerRepository.save(banner).getId();
+    }
+
+    public Page<BannerAdminMainResponseDto> findAll(Pageable pageable) {
+        return bannerRepository.findAll(pageable)
+                .map(banner -> new BannerAdminMainResponseDto(banner));
+    }
+
+    public Banner findById(Long id) {
+        return bannerRepository.findById(id).orElseThrow(() ->
+                new IllegalArgumentException("해당 banner 가 존재하지 않습니다. id=" + id));
+    }
+}

--- a/src/main/resources/application-local-resources.yml
+++ b/src/main/resources/application-local-resources.yml
@@ -6,3 +6,6 @@ resources:
 
   # 각각 local 운영 체제에 맞추어 실제로 저장되는 저장소 위치를 설정
   storage_location: c:/profile/
+
+file:
+  dir: /Users/hyeonic/project/file/

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,11 @@ spring:
         dialect: org.hibernate.dialect.MySQL57Dialect
         storage_engine: innodb
 
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 10MB
+
 logging.level:
   org.hibernate.SQL: debug
 #  org.hibernate.type: trace

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -118,3 +118,7 @@ values (21, 1, '댓글 1', now(), now()),
        (21, 2, '댓글 8', now(), now()),
        (21, 2, '댓글 9', now(), now()),
        (21, 2, '댓글 10', now(), now());
+
+insert into banner (banner_id, title, content, weight, store_file_name, upload_file_name, created_date, last_modified_date)
+values (1, '스크린샷1', '123', 100, '0bf27d50-6fdb-4f49-8ece-7da3203e411c.png', '스크린샷1.png', now(), now()),
+       (2, '스크린샷2', '123', 10, '49dc1cc3-db59-4c71-84ee-3b5366a43569.png', '스크린샷2.png', now(), now());

--- a/src/main/resources/static/js/kakao.js
+++ b/src/main/resources/static/js/kakao.js
@@ -26,7 +26,6 @@ function kakaoLogin() {
 }
 
 function isLogin() {
-    let url =  window.location.host + "/" + window.location.pathname;
     let value = localStorage.getItem('token');
     if (value === null) {
         document.getElementById('login-btn').innerText = '로그인';

--- a/src/main/resources/templates/admin/banner/banner-form.html
+++ b/src/main/resources/templates/admin/banner/banner-form.html
@@ -21,7 +21,7 @@
             </div>
             <div class="mb-3">
                 <label for="file" class="form-label">배너 이미지 파일</label>
-                <input class="form-control" type="file" id="file" name="imageFile">
+                <input class="form-control" type="file" id="file" name="imageFile" required>
             </div>
             <button type="submit" class="btn btn-secondary">저장</button>
         </form>

--- a/src/main/resources/templates/admin/banner/banner-form.html
+++ b/src/main/resources/templates/admin/banner/banner-form.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/admin-header.html :: admin-header"></head>
+<body>
+<header th:replace="fragments/admin-body-header.html :: admin-body-header"></header>
+
+<section>
+    <div class="card p-5">
+        <form onsubmit="createBanner(); return false" id="bannerForm">
+            <div class="mb-3">
+                <label for="title" class="form-label">제목</label>
+                <input type="text" class="form-control" id="title" name="title">
+            </div>
+            <div class="mb-3">
+                <label for="content" class="form-label">내용</label>
+                <input type="text" class="form-control" id="content" name="content">
+            </div>
+            <div class="mb-3">
+                <label for="file" class="form-label">배너 이미지 파일</label>
+                <input class="form-control" type="file" id="file" name="imageFile">
+            </div>
+            <button type="submit" class="btn btn-primary">저장</button>
+        </form>
+    </div>
+</section>
+
+<footer th:replace="fragments/admin-body-footer.html :: admin-body-footer"></footer>
+<script>
+    const host = window.location.protocol + '//' + window.location.host;
+
+    function createBanner() {
+        let url = host + '/api/admin/banners';
+
+        let form = document.getElementById('bannerForm');
+        let bannerForm = new FormData(form);
+
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                "Authorization": "Bearer " + localStorage.getItem("token")
+            },
+            body: bannerForm
+        }).then(response =>
+            response.json()
+        ).catch(error =>
+            alert('저장에 실패하였습니다!')
+        ).then(response => {
+                alert('배너가 등록되었습니다!')
+                location.href = host + '/admin/banners'
+        });
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/banner/banner-update-form.html
+++ b/src/main/resources/templates/admin/banner/banner-update-form.html
@@ -6,7 +6,7 @@
 
 <section>
     <div class="card p-5">
-        <form onsubmit="createBanner(); return false" id="bannerForm">
+        <form onsubmit="updateBanner(); return false" id="bannerForm">
             <div class="mb-3">
                 <label for="title" class="form-label">제목</label>
                 <input type="text" class="form-control" id="title" name="title">
@@ -23,7 +23,7 @@
                 <label for="file" class="form-label">배너 이미지 파일</label>
                 <input class="form-control" type="file" id="file" name="imageFile">
             </div>
-            <button type="submit" class="btn btn-secondary">저장</button>
+            <button type="submit" class="btn btn-secondary">수정</button>
         </form>
     </div>
 </section>
@@ -31,15 +31,38 @@
 <footer th:replace="fragments/admin-body-footer.html :: admin-body-footer"></footer>
 <script>
     const host = window.location.protocol + '//' + window.location.host;
+    const id = getParameter('id');
 
-    function createBanner() {
-        let url = host + '/api/admin/banners';
+    fetchBanner()
+
+    function fetchBanner() {
+        let url = host + '/api/admin/banners/' + id;
+
+        fetch(url, {
+            method: 'GET',
+            headers: {
+                "Authorization": "Bearer " + localStorage.getItem("token")
+            }
+        }).then(response =>
+            response.json()
+        ).catch(error =>
+            alert('조회에 실패하였습니다!')
+        ).then(response => {
+            let banner = response.data;
+            document.getElementById('title').value = banner.title;
+            document.getElementById('content').value = banner.content;
+            document.getElementById('weight').value = banner.weight;
+        });
+    }
+
+    function updateBanner() {
+        let url = host + '/api/admin/banners/' + id;
 
         let form = document.getElementById('bannerForm');
         let bannerForm = new FormData(form);
 
         fetch(url, {
-            method: 'POST',
+            method: 'PUT',
             headers: {
                 "Authorization": "Bearer " + localStorage.getItem("token")
             },
@@ -47,11 +70,18 @@
         }).then(response =>
             response.json()
         ).catch(error =>
-            alert('저장에 실패하였습니다!')
+            alert('수정에 실패하였습니다!')
         ).then(response => {
-                alert('배너가 등록되었습니다!')
-                location.href = host + '/admin/banners'
+            alert('배너가 수정되었습니다!')
+            location.href = host + '/admin/banners'
         });
+    }
+
+    function getParameter(name) {
+        name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+        let regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+            results = regex.exec(location.search);
+        return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
     }
 </script>
 </body>

--- a/src/main/resources/templates/admin/banner/banners.html
+++ b/src/main/resources/templates/admin/banner/banners.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/admin-header.html :: admin-header"></head>
+<body>
+<header th:replace="fragments/admin-body-header.html :: admin-body-header"></header>
+
+<section>
+    <div class="container-fluid">
+        <div class="row mb-3 align-items-center">
+            <div class="col">
+                <div class="fs-3 fw-bold">배너 목록</div>
+            </div>
+            <div class="col">
+                <a class="btn btn-secondary" href="/admin/banner/new">배너 생성</a>
+            </div>
+        </div>
+    </div>
+    <table class="table table-hover">
+        <thead class="table-light">
+        <tr>
+            <th scope="col">#</th>
+            <th scope="col">제목</th>
+            <th scope="col">내용</th>
+            <!--            <th scope="col">가중치</th>-->
+            <th scope="col">생성 시간</th>
+            <th scope="col">수정 시간</th>
+        </tr>
+        </thead>
+        <tbody id="table-body">
+        </tbody>
+    </table>
+    <nav aria-label="Page navigation example">
+        <ul class="pagination">
+            <li class="page-item">
+                <a class="page-link" onclick="prevPage()" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li class="page-item">
+                <a class="page-link" onclick="nextPage()" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+</section>
+
+<footer th:replace="fragments/admin-body-footer.html :: admin-body-footer"></footer>
+<script>
+    const host = window.location.protocol + '//' + window.location.host;
+
+    let pageable = {
+        page: 0,
+        size: 10,
+        totalPage: 0
+    }
+
+    creatTable();
+
+    function prevPage() {
+        if (pageable.page > 0) {
+            pageable.page -= 1;
+            if (document.getElementById('keyword').value !== "") {
+                search();
+            } else {
+                creatTable();
+            }
+        } else {
+            alert('첫 번째 입니다.');
+        }
+    }
+
+    function nextPage() {
+        if (pageable.page < pageable.totalPage - 1) {
+            pageable.page += 1;
+            if (document.getElementById('keyword').value !== "") {
+                search();
+            } else {
+                creatTable();
+            }
+        } else {
+            alert('마지막 입니다.');
+        }
+    }
+
+    async function creatTable() {
+        let tbody = document.getElementById('table-body');
+        removeTable();
+
+        let data = await fetchBanners();
+        pageable.totalPage = data.totalPages;
+
+        let banners = data.content;
+        for (let key in banners) {
+            let row =
+                '<tr>' +
+                '   <th class="pb-3 pt-3">' + banners[key].id + '</th>' +
+                '   <td class="pb-3 pt-3">' + banners[key].title + '</td>' +
+                '   <td class="pb-3 pt-3">' + banners[key].content + '</td>' +
+                // '   <td class="pb-3 pt-3">' + banners[key].weight + '</td>' +
+                '   <td class="pb-3 pt-3">' + banners[key].createdDate + '</td>' +
+                '   <td class="pb-3 pt-3">' + banners[key].lastModifiedDate + '</td>' +
+                '</tr>'
+            tbody.innerHTML += row;
+        }
+    }
+
+    async function fetchBanners() {
+        let url = host + '/api/admin/banners?page=' + pageable.page + '&size=' + pageable.size;
+
+        let fetchData = await fetch(url, {
+            headers: {
+                "Content-type": "application/json",
+                "Authorization": "Bearer " + localStorage.getItem("token")
+            }
+        }).then((response) => {
+            if (response.status === 401) {
+                alert('로그인 후 사용해주세요!');
+            } else if (response.status === 404) {
+                alert('권한이 없는 회원입니다!');
+            }
+            return response.json();
+        });
+
+        return fetchData.data;
+    }
+
+    function removeTable() {
+        let tbody = document.getElementById('table-body');
+        for (let i = 0; i < pageable.size; i++) {
+            let row = document.getElementById('tr-' + i);
+            if (row != null) {
+                tbody.removeChild(row);
+            }
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/banner/banners.html
+++ b/src/main/resources/templates/admin/banner/banners.html
@@ -11,7 +11,7 @@
                 <div class="fs-3 fw-bold">배너 목록</div>
             </div>
             <div class="col">
-                <a class="btn btn-secondary" href="/admin/banner/new">배너 생성</a>
+                <a class="btn btn-secondary" href="/admin/banners/new">배너 생성</a>
             </div>
         </div>
     </div>
@@ -21,9 +21,11 @@
             <th scope="col">#</th>
             <th scope="col">제목</th>
             <th scope="col">내용</th>
-            <!--            <th scope="col">가중치</th>-->
+            <th scope="col">가중치</th>
             <th scope="col">생성 시간</th>
             <th scope="col">수정 시간</th>
+            <th scope="col"></th>
+            <th scope="col"></th>
         </tr>
         </thead>
         <tbody id="table-body">
@@ -92,17 +94,36 @@
 
         let banners = data.content;
         for (let key in banners) {
+            let url = '\'' + '/admin/banners/update?id=' + banners[key].id + '\'';
             let row =
-                '<tr>' +
-                '   <th class="pb-3 pt-3">' + banners[key].id + '</th>' +
+                '<tr id="tr-' + key + '">' +
+                '   <td class="pb-3 pt-3">' + banners[key].id + '</td>' +
                 '   <td class="pb-3 pt-3">' + banners[key].title + '</td>' +
                 '   <td class="pb-3 pt-3">' + banners[key].content + '</td>' +
-                // '   <td class="pb-3 pt-3">' + banners[key].weight + '</td>' +
+                '   <td class="pb-3 pt-3">' + banners[key].weight + '</td>' +
                 '   <td class="pb-3 pt-3">' + banners[key].createdDate + '</td>' +
                 '   <td class="pb-3 pt-3">' + banners[key].lastModifiedDate + '</td>' +
+                '   <td class="pb-3 pt-3">' +
+                '       <a class="btn btn-secondary" href=' + url + '>수정</a>' +
+                '   </td>' +
+                '   <td class="pb-3 pt-3">' +
+                '       <a class="btn btn-secondary" onclick="removeBanner(' + banners[key].id + ')">삭제</a>' +
+                '   </td>' +
                 '</tr>'
             tbody.innerHTML += row;
         }
+    }
+
+    function removeBanner(id) {
+        let url = host + '/api/admin/banners/' + id;
+        fetch(url, {
+            method: 'DELETE',
+            headers: {
+                "Authorization": "Bearer " + localStorage.getItem("token")
+            }
+        }).then(response => {
+            location.reload()
+        })
     }
 
     async function fetchBanners() {

--- a/src/main/resources/templates/fragments/admin-body-header.html
+++ b/src/main/resources/templates/fragments/admin-body-header.html
@@ -31,6 +31,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="/admin/suggestions">건의 사항 확인</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/admin/banners">배너 관리</a>
+                    </li>
                 </ul>
                 <button id="login-btn" class="d-flex btn btn-secondary" onclick="kakaoLogin()"></button>
             </div>


### PR DESCRIPTION
#196 

![image](https://user-images.githubusercontent.com/59357153/125418440-ad1ab890-5b12-403e-b7d6-4b8f692df07f.png)
배너 목록을 확인하는 부분입니다. 

상단 부분에 배너 생성을 누르면 배너를 생성하는 페이지로 이동합니다.

![image](https://user-images.githubusercontent.com/59357153/125418597-ce8b45a9-8d9a-48d6-87af-384ee68419ba.png)
input 태그에 값을 적절히 입력하고 저장을 누르면 배너 광고가 추가됩니다. 추가적으로 이미지는 필수 값으로 설정하였습니다. 

가중치 내림차순으로 정렬하여 조회합니다. 가중치 값이 클 수록 먼저 등장할 수 있도록 정렬하였습니다.
![image](https://user-images.githubusercontent.com/59357153/125418776-ba64753e-6b7c-4ecc-9aff-ee51a5336aba.png)

수정 버튼을 누르면 수정 페이지로 이동합니다. text로 된 데이터들은 모두 기존 것을 가져오도록 하였지만 이미지의 경우 기존 이미지를 가져오는 방법을 아직 찾지 못하여 새롭게 등록해야 합니다. 하지만 수정이 완료되면 기존 이미지는 삭제 되도록 조치를 취하였기 때문에 이미지가 계속적으로 쌓이는 부분은 해결하였습니다.

![image](https://user-images.githubusercontent.com/59357153/125418977-8fc580f0-201b-4af5-87dc-21c5e1b04886.png)

마지막으로 삭제 버튼을 클릭하면 등록한 이미지 파일과 함께 데이터베이스에서 삭제 되고 조회 페이지를 reload 합니다.
![image](https://user-images.githubusercontent.com/59357153/125419094-05d3916e-d449-43ae-9e47-484d503da7a0.png)

admin의 경우 모두 admin 권한이 있을 때만 조회 및 수정, 삭제가 가능하도록 설정하였습니다.

마지막으로 front에서 조회하기 위한 api입니다.
![image](https://user-images.githubusercontent.com/59357153/125419266-48a50ec6-a785-4aaf-8568-ee75b00357a5.png)

findAll을 통하여 조회를 진행합니다. 해당 api에는 배너의 정보가 들어있고 uploadFile안에 storeFileName을 활용하여 이미지 파일에 접근해야 합니다.

이미지 파일 접근을 위한 api입니다.
![image](https://user-images.githubusercontent.com/59357153/125419464-24b86e65-9491-4d66-976e-fb9a1b044d9d.png)
위에서 조회한 storeFileName을 활용하여 이미지 바이너리를 반환합니다. front는 img 태그에 src에 storeFileName이 포함된 url을 입력하면 해당 태그에 맞춰 서버에 있는 이미지 파일이 그려집니다.
ex)
```html
<img src="/api/banners/images/0bf27d50-6fdb-4f49-8ece-7da3203e411c.png" /> 
```