### PR TITLE
[FEAT] follow 목적에 따른 조회 기능 추가 

### DIFF
--- a/src/main/java/com/skhuedin/skhuedin/controller/api/FollowApiController.java
+++ b/src/main/java/com/skhuedin/skhuedin/controller/api/FollowApiController.java
@@ -69,9 +69,16 @@ public class FollowApiController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @GetMapping("users/{toUserId}/follows")
+    @GetMapping("follows/to-user/{toUserId}")
     public ResponseEntity<? extends BasicResponse> findByToUserId(@PathVariable("toUserId") Long toUserId) {
         List<FollowMainResponseDto> follows = followService.findByToUserId(toUserId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(follows));
+    }
+
+    @GetMapping("follows/from-user/{fromUserId}")
+    public ResponseEntity<? extends BasicResponse> findByFromUserId(@PathVariable("fromUserId") Long fromUserId) {
+        List<FollowMainResponseDto> follows = followService.findByFromUserId(fromUserId);
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse<>(follows));
     }

--- a/src/main/java/com/skhuedin/skhuedin/domain/Follow.java
+++ b/src/main/java/com/skhuedin/skhuedin/domain/Follow.java
@@ -25,11 +25,11 @@ public class Follow extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "toUser_id")
+    @JoinColumn(name = "to_user_id")
     private User toUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "fromUser_id")
+    @JoinColumn(name = "from_user_id")
     private User fromUser;
 
     @Builder

--- a/src/main/java/com/skhuedin/skhuedin/dto/follow/FollowSaveRequestDto.java
+++ b/src/main/java/com/skhuedin/skhuedin/dto/follow/FollowSaveRequestDto.java
@@ -4,10 +4,12 @@ import com.skhuedin.skhuedin.domain.Follow;
 import com.skhuedin.skhuedin.domain.User;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
+@NoArgsConstructor
 public class FollowSaveRequestDto {
 
     @NotNull(message = "toUser의 id는 null이 될 수 없습니다.")
@@ -22,9 +24,9 @@ public class FollowSaveRequestDto {
         this.fromUserId = fromUserId;
     }
 
-    public Follow toEntity(User toUSer, User fromUser) {
+    public Follow toEntity(User toUser, User fromUser) {
         return Follow.builder()
-                .toUser(toUSer)
+                .toUser(toUser)
                 .fromUser(fromUser)
                 .build();
     }

--- a/src/main/java/com/skhuedin/skhuedin/dto/user/UserSaveRequestDto.java
+++ b/src/main/java/com/skhuedin/skhuedin/dto/user/UserSaveRequestDto.java
@@ -20,9 +20,7 @@ public class UserSaveRequestDto {
     private String userImageUrl;
     private String entranceYear;
     private String graduationYear;
-
     private Role role;
-
 
     @Builder
     public UserSaveRequestDto(String email,
@@ -56,7 +54,6 @@ public class UserSaveRequestDto {
             this.role = Role.USER;
         }
         User user = User.builder()
-
                 .email(this.email)
                 .password(this.password)
                 .name(this.name)

--- a/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
+++ b/src/main/java/com/skhuedin/skhuedin/file/FileStore.java
@@ -1,6 +1,7 @@
 package com.skhuedin.skhuedin.file;
 
 import com.skhuedin.skhuedin.domain.UploadFile;
+import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,6 +11,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 @Component
+@NoArgsConstructor
 public class FileStore {
 
     @Value("${file.dir}")

--- a/src/main/java/com/skhuedin/skhuedin/repository/FollowRepository.java
+++ b/src/main/java/com/skhuedin/skhuedin/repository/FollowRepository.java
@@ -1,11 +1,32 @@
 package com.skhuedin.skhuedin.repository;
 
 import com.skhuedin.skhuedin.domain.Follow;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    List<Follow> findByToUserId(Long id);
+    @EntityGraph(attributePaths = {"toUser", "fromUser"})
+    @Query("select f " +
+            "from Follow f " +
+            "where f.toUser.id = :id")
+    List<Follow> findByToUserId(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {"toUser", "fromUser"})
+    @Query("select f " +
+            "from Follow f " +
+            "where f.fromUser.id = :id")
+    List<Follow> findByFromUserId(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {"toUser", "fromUser"})
+    @Query("select f " +
+            "from Follow f " +
+            "where f.toUser.id = :toUserId and f.fromUser.id = :fromUserId")
+    Follow findByToUserIdAndFromUserId(@Param("toUserId") Long toUserId, @Param("fromUserId") Long fromUserId);
+
+    Boolean existsByToUserIdAndFromUserId(Long toUserId, Long fromUserId);
 }

--- a/src/main/java/com/skhuedin/skhuedin/service/BannerService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/BannerService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.util.List;
 
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/com/skhuedin/skhuedin/service/FollowService.java
+++ b/src/main/java/com/skhuedin/skhuedin/service/FollowService.java
@@ -23,6 +23,13 @@ public class FollowService {
 
     @Transactional
     public Long save(FollowSaveRequestDto requestDto) {
+
+        if (followRepository.existsByToUserIdAndFromUserId(requestDto.getToUserId(), requestDto.getFromUserId())) {
+            return followRepository.findByToUserIdAndFromUserId(
+                    requestDto.getToUserId(), requestDto.getFromUserId())
+                    .getId();
+        }
+
         User toUser = getUser(requestDto.getToUserId());
         User fromUser = getUser(requestDto.getFromUserId());
 
@@ -60,6 +67,13 @@ public class FollowService {
 
     public List<FollowMainResponseDto> findByToUserId(Long toUserId) {
         return followRepository.findByToUserId(toUserId)
+                .stream()
+                .map(follow -> new FollowMainResponseDto(follow))
+                .collect(Collectors.toList());
+    }
+
+    public List<FollowMainResponseDto> findByFromUserId(Long fromUserId) {
+        return followRepository.findByFromUserId(fromUserId)
                 .stream()
                 .map(follow -> new FollowMainResponseDto(follow))
                 .collect(Collectors.toList());

--- a/src/test/java/com/skhuedin/skhuedin/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/skhuedin/skhuedin/repository/FollowRepositoryTest.java
@@ -11,11 +11,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
 @Sql("/truncate.sql")
@@ -110,5 +108,66 @@ class FollowRepositoryTest {
 
         // then
         assertEquals(follows.size(), 3);
+    }
+
+    @Test
+    @DisplayName("fromUser 가 follow 한 toUser 목록을 조회하는 테스트")
+    void findByFromUserId() {
+
+        // given
+        Follow follow = Follow.builder()
+                .toUser(toUser)
+                .fromUser(fromUser1)
+                .build();
+
+        followRepository.save(follow);
+
+        // when
+        List<Follow> follows = followRepository.findByFromUserId(follow.getFromUser().getId());
+
+        // then
+        assertEquals(1, follows.size());
+    }
+
+    @Test
+    @DisplayName("toUserId 와 fromUserId 로 follow 를 조회하는 테스트")
+    void findByToUserIdAndFromUserId() {
+
+        // given
+        Follow follow = Follow.builder()
+                .toUser(toUser)
+                .fromUser(fromUser1)
+                .build();
+
+        followRepository.save(follow);
+
+        // when
+        Follow findFollow = followRepository.findByToUserIdAndFromUserId(
+                follow.getToUser().getId(),
+                follow.getFromUser().getId());
+
+        // then
+        assertEquals(follow, findFollow);
+    }
+
+    @Test
+    @DisplayName("fromUser 가 toUser 의 follow 유무를 확인하는 테스트")
+    void existsByToUserIdAndFromUserId() {
+
+        // given
+        Follow follow = Follow.builder()
+                .toUser(toUser)
+                .fromUser(fromUser1)
+                .build();
+
+        Follow save = followRepository.save(follow);
+
+        // when
+        Boolean exists = followRepository.existsByToUserIdAndFromUserId(
+                follow.getToUser().getId(),
+                follow.getFromUser().getId());
+
+        // then
+        assertEquals(true, exists);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,9 @@ resources:
   # 각각 local 운영 체제에 맞추어 실제로 저장되는 저장소 위치를 설정
   storage_location: c:/profile/
 
+file:
+  dir: /Users/hyeonic/project/file/
+
 social:
   naver:
     login: ""


### PR DESCRIPTION
#200 

follow에서 fromUser를 기반으로 조회하는 것과 toUser를 기반으로 조회하는 것을 나눠 추가하였습니다. 추가적으로 기존에 follow 목록에 존재한다면 추가적으로 저장되지 않도록 검증하는 부분을 추가하였습니다.

기존에 테스트 코드 쪽 application.yml에 dir.file 이 누락되어 생긴 오류를 해결하였습니다